### PR TITLE
Feature/#56 예외처리 및 프로그램 테스트

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,18 @@ HTTP		:=	\
 				HttpResponseBuilder \
 				Utils \
 				DefaultMethodExecutor \
-				ExtendedResponseHeaderAdder \
 				ResponseHeaderAdder \
-				CgiMethodExecutor 
-
+				CgiMethodExecutor \
+				ServerErrors \
+				
 SERVER		:=	\
 				ServerHandler \
  				Server \
  				Client
 
-# CONFIG		:=	$(addprefix config/, $(CONFIG))
-# HTTP		:=	$(addprefix http/, $(HTTP))
-# SERVER		:=	$(addprefix server/, $(SERVER))
+CONFIG		:=	$(addprefix config/, $(CONFIG))
+HTTP		:=	$(addprefix http/, $(HTTP))
+SERVER		:=	$(addprefix server/, $(SERVER))
 
 FILENAME	=	\
  				main \

--- a/include/http/HttpRequestMessage.hpp
+++ b/include/http/HttpRequestMessage.hpp
@@ -8,26 +8,13 @@ class HttpRequestMessage : public HttpMessage
     private:
         string httpMethod;
         string requestTarget;
-        void parseRequestMessage(const string &requestMessage);
         bool chunkedFlag;
-        void parseUri();
-
-        string requestUri;
-        string uri;
-        string filename;
-        string args;
-        string queryString;
-
+        void parseRequestMessage(const string &requestMessage);
     public:
         HttpRequestMessage(const string &requestMessage);
         string getHttpMethod() const;
         string getRequestTarget() const;
         int getChunkedFlag() const;
-        string getRequestUri() const;
-        string getUri() const;
-        string getFilename() const;
-        string getArgs() const;
-        string getQueryString() const;
 };
 
 #endif

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -2,11 +2,13 @@
 # define HTTP_RESPONSE_BUILDER_HPP
 # include "HttpRequestMessage.hpp"
 # include "HttpResponseMessage.hpp"
-# include "IMethodExecutor.hpp"
+# include "DefaultMethodExecutor.hpp"
+# include "CgiMethodExecutor.hpp"
 # include "WebservValues.hpp"
 # include "ServerConfig.hpp"
 # include "LocationConfig.hpp"
 # include "ResponseHeaderAdder.hpp"
+# include "ServerErrors.hpp"
 # include <vector>
 # include <sys/stat.h>
 # include <unistd.h>
@@ -14,42 +16,55 @@
 class Server;
 
 class HttpResponseBuilder {
-
     private:
-        HttpRequestMessage *requestMessage;
+        HttpRequestMessage * requestMessage;
         HttpResponseMessage *responseMessage;
         LocationConfig locationConfig;
         const Server *server;
         WebservValues *webservValues;
-
+        
+        // requestUril parsing 결과
+        string requestUri;
+        string uri;
+        string filename;
+        string args;
+        string queryString;
+        
+        // request info
         string resourcePath; // locations를 거쳐 찾은 진짜 경로
         string requestBody;
+        
+        // reponse information 
+        string contentType;
+        string responseBody;
+        int errorCode; // statudCode
+
+        // flag
         bool needMoreMessageFlag; 
         bool needCgiFlag;
+        bool end;
+
+        void clear();
+        void parseRequestUri(const string & requestTarget);
+        int checkAcceptMethod(const vector<string> & acceptMethods, const string & httpMethod);
+        int validateResource(const vector<string> & indexes, const string & httpMethod);
         void initWebservValues();
-        int errorCode;
-        string errorPhrase;
-        bool  ready;
+        void execute(IMethodExecutor & methodExecutor);
+        void parseCgiProduct();
+        void createResponseMessage();
     public:
         HttpResponseBuilder(const Server *server, WebservValues & webservValues);
-        void build(IMethodExecutor & methodExecutor);
-        void parseCgiProduct(string & response, string & contentType);
+        void initiate(const string & request);
         void addRequestMessage(const string &request);
-        string getResourcePath() const;
-        string findReasonPhrase(const int &statusCode);
-        bool getNeedMoreMessageFlag() const;
-        bool getNeedCgiFlag() const;
+        void build(IMethodExecutor & methodExecutor);
+        
+        //getter setter
         HttpResponseMessage getResponseMessage() const;
         HttpRequestMessage getRequestMessage() const;
-        void initiate(const string & request);
-        void clear();
         LocationConfig getLocationConfig() const;
-        int verifyUrl();
-        void setErrorCode(const int & num);
-        int getErrorCode() const;
-        void setErrorPhrase(const string & errorPhrase);
-        string getErrorPhrase() const;
-        int checkAcceptMethod();
+        bool getNeedMoreMessageFlag() const;
+        bool getNeedCgiFlag() const;
+        bool getEnd() const;
 };
 
 #endif

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -27,6 +27,9 @@ class HttpResponseBuilder {
         bool needMoreMessageFlag; 
         bool needCgiFlag;
         void initWebservValues();
+        int errorCode;
+        string errorPhrase;
+        bool  ready;
     public:
         HttpResponseBuilder(const Server *server, WebservValues & webservValues);
         void build(IMethodExecutor & methodExecutor);
@@ -40,5 +43,13 @@ class HttpResponseBuilder {
         HttpRequestMessage getRequestMessage() const;
         void initiate(const string & request);
         void clear();
+        LocationConfig getLocationConfig() const;
+        int verifyUrl();
+        void setErrorCode(const int & num);
+        int getErrorCode() const;
+        void setErrorPhrase(const string & errorPhrase);
+        string getErrorPhrase() const;
+        int checkAcceptMethod();
 };
+
 #endif

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -6,6 +6,7 @@
 # include "CgiMethodExecutor.hpp"
 # include "WebservValues.hpp"
 # include "ServerConfig.hpp"
+# include "Server.hpp"
 # include "LocationConfig.hpp"
 # include "ResponseHeaderAdder.hpp"
 # include "ServerErrors.hpp"

--- a/include/http/ResponseHeaderAdder.hpp
+++ b/include/http/ResponseHeaderAdder.hpp
@@ -7,6 +7,7 @@
 # include "ResponseHeaderAdder.hpp"
 # include "ServerConfig.hpp"
 # include "Utils.hpp"
+
 using namespace std;
 
 class ResponseHeaderAdder
@@ -15,11 +16,12 @@ class ResponseHeaderAdder
         const HttpRequestMessage & requestMessage;
         HttpResponseMessage & responseMessage;
         const LocationConfig & locationConfig;
-        string & response;
+        const string & responseBody;
         const string & resourcePath;
+        const string & contentType;
     public:
-        ResponseHeaderAdder(const HttpRequestMessage & requestMessage, HttpResponseMessage & responseMessage,\
-            const LocationConfig & locationConfig, string & response, const string & resourcePath);
+        ResponseHeaderAdder(const HttpRequestMessage & requestMessage, HttpResponseMessage & responseMessage, \
+            const LocationConfig & locationConfig, const string & responseBody, const string & resourcePath, const string & contentType);
         void executeAll();
         void addContentTypeHeader(const string & contentType);
         void addContentLengthHeader(const string & responseBody);
@@ -27,7 +29,9 @@ class ResponseHeaderAdder
         void addAllowHeader(const vector<string> & acceptMethods);
         void addDateHeader();
         void parseCgiProduct(string & response, string & contentType);
-//        void addCacheControlHeader(const HttpRequestMessage & requestMessage, HttpResponseMessage & responseMessage);
+        void setResponseBody(string responseBody);
+        void setResourcePath(string resourcePath);
+        void setContentType(string contentType);
 };
 
 #endif

--- a/include/http/ServerErrors.hpp
+++ b/include/http/ServerErrors.hpp
@@ -1,0 +1,17 @@
+#ifndef SERVER_ERROR_HPP
+# define SERVER_ERROR_HPP
+# include <iostream>
+# include <string>
+# include "Utils.hpp"
+
+using namespace std;
+
+class ServerErrors
+{
+    public:
+        string findReasonPhrase(const int &statusCode) const;
+        string findErrorMessage(const int &statusCode) const;
+        string generateErrorHtml(const int & statusCode) const;
+};
+
+#endif

--- a/include/http/WebservValues.hpp
+++ b/include/http/WebservValues.hpp
@@ -11,11 +11,13 @@ class WebservValues
 {
     private:
         map<string, string> envList;
+        map<string, string> addressValues;
     public:
         string getValue(const string &key) const;
         string convert(const string &input) const;
         void insert(const string &key, const string &value);
         void insert(const string &key, const uint16_t &value);
+        void initEnvList();
         void clear();
 };
 

--- a/srcs/http/DefaultMethodExecutor.cpp
+++ b/srcs/http/DefaultMethodExecutor.cpp
@@ -4,52 +4,30 @@ int DefaultMethodExecutor::getMethod(const string &resourcePath, string &respons
 {
     int statusCode;
     ifstream file(resourcePath);
-    if (access(resourcePath.c_str(), F_OK) == 0) {
-        if (file.is_open()) {
-            getline(file, response, '\0');
-            statusCode = 200; //ok
-            file.close();
-        }
-        else {
-            statusCode = 500; // internal server error
-        }
+    if (file.fail()) {
+        return 500;
     }
-    else {
-        statusCode = 404; //not found
-    }
-    return statusCode;
+    getline(file, response, '\0');
+    file.close();
+    return 200;
 }
 
 int DefaultMethodExecutor::postMethod(const string &resourcePath, const string &request, string &response)
 {
-    int statusCode;
     ofstream file(resourcePath);
-    if (file.is_open()) {
-        file << request;
-        file.close();
-        statusCode = 201; // Created
-    }
-    else {
-        statusCode = 500;
-    }
-    return statusCode;
+    
+    if (file.fail()) {
+        return 500;
+    }   
+    file << request;
+    file.close();
+    return 201;
 }
 
 int DefaultMethodExecutor::deleteMethod(const string &resourcePath) const
 {
-    int statusCode;
-    if (access(resourcePath.c_str(), F_OK) == 0) {
-        int ret = remove(resourcePath.c_str());
-        if (ret == 0) {
-            statusCode = 204; // No Content
-        }
-        else {
-            statusCode = 500;
-        }
+    if (remove(resourcePath.c_str()) != 0) {
+        return 500;
     }
-    else {
-        statusCode = 404;
-        
-    }
-    return statusCode;
+    return 204;
 }

--- a/srcs/http/HttpRequestMessage.cpp
+++ b/srcs/http/HttpRequestMessage.cpp
@@ -7,37 +7,6 @@ HttpRequestMessage::HttpRequestMessage(const string &requestMessage)
 
 }
 
-// <경로>;<파라미터>?<질의>#<프래그먼트> 경로조각은 없다고 가정
-void HttpRequestMessage::parseUri()
-{
-    // requestUri 초기화
-    requestUri = requestTarget;
-
-    // uri 초기화
-    size_t pos = requestUri.find_first_of(";?#");
-    if (pos == string::npos) {
-        uri = requestUri;
-    }
-    else {
-        uri = requestUri.substr(0, pos);
-    }
-
-    // filename 초기화
-    filename = requestUri.substr(requestUri.find_last_of("/")+1, pos-requestUri.find_last_of("/")-1);
-
-    // args 초기화
-    pos = requestUri.find(";");
-    if (pos != string::npos) {
-        args = requestUri.substr(pos+1, min(requestUri.find("?"), requestUri.length()));
-    }
-
-    // queryString 초기화
-    pos = requestUri.find("?");
-    if (pos != string::npos) {
-        queryString = requestUri.substr(pos+1, min(requestUri.find("#"), requestUri.length())-pos-1);
-    }
-}
-
 void HttpRequestMessage::parseRequestMessage(const string &request)
 {
     vector<string> lst = Utils::split(request, "\r\n");
@@ -45,7 +14,7 @@ void HttpRequestMessage::parseRequestMessage(const string &request)
     //start line parsing
     vector<string> tmp = Utils::split(lst.at(0), " ");
     httpMethod = tmp.at(0);
-    uri = tmp.at(1);
+    requestTarget = tmp.at(1);
     serverProtocol = tmp.at(2);
     
     int byte = lst.at(0).length()+2; // 나중에 바디 시작 인덱스 알려면 필요
@@ -92,29 +61,4 @@ string HttpRequestMessage::getRequestTarget() const
 int HttpRequestMessage::getChunkedFlag() const
 {
     return chunkedFlag;
-}
-
-string HttpRequestMessage::getRequestUri() const
-{
-    return requestUri;
-}
-
-string HttpRequestMessage::getUri() const
-{
-    return uri;
-}
-
-string HttpRequestMessage::getFilename() const
-{
-    return filename;
-}
-
-string HttpRequestMessage::getArgs() const
-{
-    return args;
-}
-
-string HttpRequestMessage::getQueryString() const
-{
-    return queryString;
 }

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -60,9 +60,6 @@ void HttpResponseBuilder::parseRequestUri(const string & requestTarget)
 
 int HttpResponseBuilder::checkAcceptMethod(const vector<string> & acceptMethods, const string & httpMethod)
 {
-    string httpMethod = requestMessage->getHttpMethod();
-    const vector<string> acceptMethods = locationConfig.getAcceptMethods();
-    
     if (find(acceptMethods.begin(), acceptMethods.end(), httpMethod) == acceptMethods.end()) {
         errorCode = 405;
         return 1;

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -1,12 +1,4 @@
 #include "HttpResponseBuilder.hpp"
-#include "ServerConfig.hpp"
-#include "CgiMethodExecutor.hpp"
-#include "DefaultMethodExecutor.hpp"
-#include "Server.hpp"
-#include "errno.h"
-#include <sstream>
-#include <algorithm>
-#include <vector>
 
 HttpResponseBuilder::HttpResponseBuilder(const Server *server, WebservValues & webservValues)
     : server(server)
@@ -15,52 +7,88 @@ HttpResponseBuilder::HttpResponseBuilder(const Server *server, WebservValues & w
     this->webservValues->initEnvList();
 }
 
-void HttpResponseBuilder::initiate(const string & request)
+void HttpResponseBuilder::clear()
 {
-    clear();
-    requestMessage = new HttpRequestMessage(request);
-    responseMessage = new HttpResponseMessage();
-    if (this->requestMessage->getChunkedFlag()) {
-        requestBody = this->requestMessage->getBody();
+    if (responseMessage) {
+        delete responseMessage;
+        responseMessage = 0;
     }
-    needMoreMessageFlag = this->requestMessage->getChunkedFlag();
-    locationConfig = server->getConfig(requestMessage->getHeader("Host")).getLocConf(requestMessage->getUri());
-    needCgiFlag = locationConfig.isCgi();
-    ready = verifyUrl();
-    if (ready == false) {
-        ready = checkAcceptMethod();
-        if (ready == false) {
-            initWebservValues();
-        }
+    if (requestMessage) {
+        delete requestMessage;
+        responseMessage = 0;
+    }
+    webservValues->clear();
+    requestUri = "";
+    uri = "";
+    filename = "";
+    args = "";
+    queryString = "";
+    resourcePath = "";
+    requestBody = "";
+    contentType = "";
+    responseBody = "";
+    errorCode = 500;
+    needMoreMessageFlag = false;
+    needCgiFlag = false;
+    end = false;
+}
+
+void HttpResponseBuilder::parseRequestUri(const string & requestTarget)
+{
+    requestUri = requestTarget;
+    
+    size_t pos = requestUri.find_first_of(";?#");
+    if (pos == string::npos) {
+        uri = requestUri;
+    }
+    else {
+        uri = requestUri.substr(0, pos);
+    }
+    
+    filename = uri;
+
+    pos = requestUri.find(";");
+    if (pos != string::npos) {
+        args = requestUri.substr(pos+1, min(requestUri.find("?"), requestUri.length()));
+    }
+
+    pos = requestUri.find("?");
+    if (pos != string::npos) {
+        queryString = requestUri.substr(pos+1, min(requestUri.find("#"), requestUri.length())-pos-1);
     }
 }
 
-int HttpResponseBuilder::verifyUrl()
+int HttpResponseBuilder::checkAcceptMethod(const vector<string> & acceptMethods, const string & httpMethod)
 {
     string httpMethod = requestMessage->getHttpMethod();
-    vector<string> indexes = locationConfig.getIndexes();
+    const vector<string> acceptMethods = locationConfig.getAcceptMethods();
+    
+    if (find(acceptMethods.begin(), acceptMethods.end(), httpMethod) == acceptMethods.end()) {
+        errorCode = 405;
+        return 1;
+    }
+    return 0;
+}
+
+int HttpResponseBuilder::validateResource(const vector<string> & indexes, const string & httpMethod)
+{
     struct stat statbuf;
     string tmpPath;
     
-    if (httpMethod == "GET" or (httpMethod == "POST" and locationConfig.isCgi())) { // 요청한 리소스가 무조건 존재해야됌
-        tmpPath = locationConfig.getRoot() + requestMessage->getUri();
+    if (httpMethod == "GET" or (httpMethod == "POST" and locationConfig.isCgi())) { 
+        tmpPath = locationConfig.getRoot() + uri;
         
-        // 리소스가 존재하는가, 읽을 수 있는가 체크
         if (access(tmpPath.c_str(), F_OK) != 0) {
             errorCode = 404;
-            // errorPhrase = "File not found";
             return 1;
         }
         else if (access(tmpPath.c_str(), R_OK) != 0) {
             errorCode = 403;
-            // errorPhrase = "File access denied";
             return 1;
         }
 
-        // 리소스가 레귤러파일인가 디렉터리인가 체크
         if (stat(tmpPath.c_str(), &statbuf) < 0) {
             errorCode = 500;
-            // errorPhrase = "oops, looks like somethig went worng.";
             return 1;
         }
 
@@ -75,39 +103,31 @@ int HttpResponseBuilder::verifyUrl()
                 }
             }
             if (exist == false) {
-                // bad request 응답하거나 인덱스 페이지를 보여주거나 선택사항임, 지금은 전자.
                 errorCode = 400;
-                // errorPhrase = "Directory file";
                 return 1;
             }
         }
-        else if (S_ISREG(statbuf.st_mode)) { // 레귤러 파일 일때
-            // 앞에서 읽을 수 있는 파일인지 이미 체크했음.
+        else if (S_ISREG(statbuf.st_mode)) { 
             resourcePath = tmpPath;
         }
     }
-    else if (httpMethod == "POST") { // 요청한 패스가 존재할 수 도 없을 수 도 있음
-        // 경로가 존재하는데 폴더면 문제 발생
+    else if (httpMethod == "POST") { 
         if (access(tmpPath.c_str(), F_OK) == 0) {
-            if (S_ISDIR(statbuf.st_mode)) { // 디렉터리 일때
+            if (S_ISDIR(statbuf.st_mode)) { 
                 // bad request 응답하거나 인덱스 페이지를 보여주거나 선택사항임, 지금은 전자.
                 errorCode = 400;
-                // errorPhrase = "Directory file";
                 return 1;
             }
         }
         resourcePath = tmpPath;
     }
     else if (httpMethod == "DELETE") {
-        // 리소스가 존재하는가, 삭제 할 수 있는가 체크
         if (access(tmpPath.c_str(), F_OK) != 0) {
             errorCode = 404;
-            // errorPhrase = "File not found";
             return 1;
         }
         else if (access(tmpPath.c_str(), W_OK) != 0) {
             errorCode = 403;
-            // errorPhrase = "File access denied";
             return 1;
         }
         resourcePath = tmpPath;
@@ -115,29 +135,87 @@ int HttpResponseBuilder::verifyUrl()
     return 0;
 }
 
-int HttpResponseBuilder::checkAcceptMethod()
-{
-    string httpMethod = requestMessage->getHttpMethod();
-    const vector<string> acceptMethods = locationConfig.getAcceptMethods();
-    
-    if (find(acceptMethods.begin(), acceptMethods.end(), httpMethod) == acceptMethods.end()) {
-        errorCode = 405;
-        return 1;
-    }
-    return 0;
-}
-
 void HttpResponseBuilder::initWebservValues()
 {    
-    webservValues->insert("args", requestMessage->getArgs());
-    webservValues->insert("query_string", requestMessage->getQueryString());
+    webservValues->insert("args", args);
+    webservValues->insert("query_string", queryString);
     webservValues->insert("method", requestMessage->getHttpMethod());
     webservValues->insert("host", requestMessage->getHeader("Host"));
     webservValues->insert("content_type", locationConfig.getType(resourcePath));
     webservValues->insert("request_filename", resourcePath);
-    webservValues->insert("request_uri", requestMessage->getRequestUri());
-    webservValues->insert("uri", requestMessage->getUri());
-    webservValues->insert("document_uri", requestMessage->getUri());
+    webservValues->insert("request_uri", requestUri);
+    webservValues->insert("uri", uri);
+    webservValues->insert("document_uri", uri);
+}
+
+void HttpResponseBuilder::execute(IMethodExecutor & methodExecutor)
+{
+    string httpMethod = requestMessage->getHttpMethod();
+    
+    // 'if-None-Match', 'if-Match' 와 같은 요청 헤더 지원할 거면 여기서 분기 한번 들어감(선택사항임)
+    if (httpMethod == "GET") {
+        errorCode = methodExecutor.getMethod(resourcePath, responseBody);
+    }
+    else if(httpMethod == "POST") {
+        errorCode = methodExecutor.postMethod(resourcePath, requestBody, responseBody);
+    }
+    else if(httpMethod == "DELETE") {
+        errorCode = methodExecutor.deleteMethod(resourcePath);
+    }
+}
+
+void HttpResponseBuilder::parseCgiProduct()
+{
+    size_t newline = responseBody.find("\n\n");
+    if (newline != string::npos) {
+        string header = responseBody.substr(0, newline);
+        if (header.find(":") != string::npos) {
+            if (header.substr(0, 12) == "Content-type") {
+                contentType = Utils::ltrim(header.substr(13, header.length()-13));
+                responseBody = responseBody.substr(newline+2, responseBody.length()-newline-2);
+            }
+        }
+    }
+}
+
+void HttpResponseBuilder::createResponseMessage() {
+    ServerErrors serverErrors;
+
+    responseMessage = new HttpResponseMessage();
+    responseMessage->setServerProtocol(requestMessage->getServerProtocol());
+    responseMessage->setStatusCode(errorCode);
+    responseMessage->setReasonPhrase(serverErrors.findReasonPhrase(errorCode));
+    contentType = locationConfig.getType(resourcePath);
+    if (responseBody == "") {
+        responseBody = serverErrors.generateErrorHtml(errorCode);
+    }
+    else if (responseBody != "" && locationConfig.isCgi()) {
+        parseCgiProduct();
+    }
+    responseMessage->setBody(responseBody);
+    ResponseHeaderAdder responseHeaderAdder(*requestMessage, *responseMessage, locationConfig, responseBody, resourcePath, contentType);
+    responseHeaderAdder.executeAll();
+}
+
+void HttpResponseBuilder::initiate(const string & request)
+{
+    clear();
+    requestMessage = new HttpRequestMessage(request);
+    
+    parseRequestUri(requestMessage->getRequestTarget());
+    locationConfig = server->getConfig(requestMessage->getHeader("Host")).getLocConf(uri);
+    if ((end = checkAcceptMethod(locationConfig.getAcceptMethods(), requestMessage->getHttpMethod())) == true) {
+        createResponseMessage();
+        return;
+    }
+    if ((end = validateResource(locationConfig.getIndexes(), requestMessage->getHttpMethod())) == true) {
+        createResponseMessage();
+        return;
+    }
+    initWebservValues();
+    needMoreMessageFlag = requestMessage->getChunkedFlag();
+    needCgiFlag = locationConfig.isCgi();
+    requestBody = requestMessage->getBody();
 }
 
 void HttpResponseBuilder::addRequestMessage(const string &request)
@@ -146,8 +224,30 @@ void HttpResponseBuilder::addRequestMessage(const string &request)
     needMoreMessageFlag = newRequestMessage.getChunkedFlag();
     requestBody.append(newRequestMessage.getBody());
     
-    /* 이전과 같은 chunk 요청인지 구별하는 방법은 HTTP 메서드와 URL이 동일함을 확인, Contetn-Length 헤더가 없는것을 확인
+    /* 이전과 같은 chunk 요청인지 구별하는 방법은 HTTP 메서드와 requestTarget이 동일함을 확인, Contetn-Length 헤더가 없는것을 확인
     Transfer-Encoding: chunked 헤더가 지정되어 있는지를 확인하면 됌 */
+}
+
+void HttpResponseBuilder::build(IMethodExecutor & methodExecutor)
+{
+    execute(methodExecutor);
+    createResponseMessage();
+    end = true;  
+}
+
+HttpRequestMessage HttpResponseBuilder::getRequestMessage() const
+{
+    return *requestMessage;
+}
+
+HttpResponseMessage HttpResponseBuilder::getResponseMessage() const
+{
+    return *responseMessage;
+}
+
+LocationConfig HttpResponseBuilder::getLocationConfig() const
+{
+    return locationConfig;
 }
 
 bool HttpResponseBuilder::getNeedMoreMessageFlag() const
@@ -160,108 +260,7 @@ bool HttpResponseBuilder::getNeedCgiFlag() const
     return needCgiFlag;
 }
 
-void HttpResponseBuilder::build(IMethodExecutor & methodExecutor)
+bool HttpResponseBuilder::getEnd() const
 {
-    string httpMethod = requestMessage->getHttpMethod();
-    string response;
-    int statusCode;
-    
-    // 'if-None-Match', 'if-Match' 와 같은 요청 헤더 지원할 거면 여기서 분기 한번 들어감(선택사항임)
-    
-    if (httpMethod == "GET") {
-        statusCode = methodExecutor.getMethod(resourcePath, response);
-    }
-    else if(httpMethod == "POST") {
-        statusCode = methodExecutor.postMethod(resourcePath, requestBody, response);
-    }
-    else if(httpMethod == "DELETE") {
-        statusCode = methodExecutor.deleteMethod(resourcePath);
-    }
-    
-    responseMessage->setServerProtocol(requestMessage->getServerProtocol());
-    responseMessage->setStatusCode(statusCode);
-    responseMessage->setReasonPhrase(findReasonPhrase(statusCode));
-    
-    ResponseHeaderAdder responseHeaderAdder(*requestMessage, *responseMessage, locationConfig, response, resourcePath);
-    responseHeaderAdder.executeAll();
-    //이후에 response가 적절하게 파싱되어있을 거임
-    responseMessage->setBody(response);
-}
-
-string HttpResponseBuilder::getResourcePath() const
-{
-    return resourcePath;
-}
-
-string HttpResponseBuilder::findReasonPhrase(const int &statusCode)
-{
-    switch(statusCode) {
-        case 200:
-            return "OK";
-        case 201:
-            return "Created";
-        case 204:
-            return "No Content";
-        case 400:
-            return "Bad Request";
-        case 404:
-            return "Not Found";
-        case 405:
-            return "Method Not Allowed";
-        case 500:
-            return "Internal Server Error";
-    }
-    return "Internal Server Error";
-}
-
-HttpResponseMessage HttpResponseBuilder::getResponseMessage() const
-{
-    return *responseMessage;
-}
-
-HttpRequestMessage HttpResponseBuilder::getRequestMessage() const
-{
-    return *requestMessage;
-}
-
-void HttpResponseBuilder::clear()
-{
-    if (responseMessage) {
-        delete responseMessage;
-        responseMessage = 0;
-    }
-    if (requestMessage) {
-        delete requestMessage;
-        responseMessage = 0;
-    }
-    webservValues->clear();
-    resourcePath = "";
-    requestBody = "";
-    needMoreMessageFlag = false;
-    needCgiFlag = false;
-}
-
-LocationConfig HttpResponseBuilder::getLocationConfig() const
-{
-    return locationConfig;
-}
-
-void HttpResponseBuilder::setErrorCode(const int & num)
-{
-    errorCode = num;
-}
-
-int HttpResponseBuilder::getErrorCode() const
-{
-    return errorCode;
-}
-
-void HttpResponseBuilder::setErrorPhrase(const string & errorPhrase)
-{
-    this->errorPhrase = errorPhrase;
-}
-
-string HttpResponseBuilder::getErrorPhrase() const
-{
-    return errorPhrase;
+    return end;
 }

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -3,6 +3,7 @@
 #include "CgiMethodExecutor.hpp"
 #include "DefaultMethodExecutor.hpp"
 #include "Server.hpp"
+#include "errno.h"
 #include <sstream>
 #include <algorithm>
 #include <vector>
@@ -11,6 +12,7 @@ HttpResponseBuilder::HttpResponseBuilder(const Server *server, WebservValues & w
     : server(server)
 {
     this->webservValues = &webservValues;
+    this->webservValues->initEnvList();
 }
 
 void HttpResponseBuilder::initiate(const string & request)
@@ -24,61 +26,128 @@ void HttpResponseBuilder::initiate(const string & request)
     needMoreMessageFlag = this->requestMessage->getChunkedFlag();
     locationConfig = server->getConfig(requestMessage->getHeader("Host")).getLocConf(requestMessage->getUri());
     needCgiFlag = locationConfig.isCgi();
-    initWebservValues();
+    ready = verifyUrl();
+    if (ready == false) {
+        ready = checkAcceptMethod();
+        if (ready == false) {
+            initWebservValues();
+        }
+    }
+}
+
+int HttpResponseBuilder::verifyUrl()
+{
+    string httpMethod = requestMessage->getHttpMethod();
+    vector<string> indexes = locationConfig.getIndexes();
+    struct stat statbuf;
+    string tmpPath;
+    
+    if (httpMethod == "GET" or (httpMethod == "POST" and locationConfig.isCgi())) { // 요청한 리소스가 무조건 존재해야됌
+        tmpPath = locationConfig.getRoot() + requestMessage->getUri();
+        
+        // 리소스가 존재하는가, 읽을 수 있는가 체크
+        if (access(tmpPath.c_str(), F_OK) != 0) {
+            errorCode = 404;
+            // errorPhrase = "File not found";
+            return 1;
+        }
+        else if (access(tmpPath.c_str(), R_OK) != 0) {
+            errorCode = 403;
+            // errorPhrase = "File access denied";
+            return 1;
+        }
+
+        // 리소스가 레귤러파일인가 디렉터리인가 체크
+        if (stat(tmpPath.c_str(), &statbuf) < 0) {
+            errorCode = 500;
+            // errorPhrase = "oops, looks like somethig went worng.";
+            return 1;
+        }
+
+        if(S_ISDIR(statbuf.st_mode)) { // 디렉터리 일때
+            bool exist = false;
+            for (int i = 0; i < indexes.size(); i++) {
+                string resourcePathTmp = tmpPath+indexes.at(i);
+                if (access(resourcePathTmp.c_str(), R_OK) == 0) {
+                    resourcePath = resourcePathTmp;
+                    exist = true;
+                    break;
+                }
+            }
+            if (exist == false) {
+                // bad request 응답하거나 인덱스 페이지를 보여주거나 선택사항임, 지금은 전자.
+                errorCode = 400;
+                // errorPhrase = "Directory file";
+                return 1;
+            }
+        }
+        else if (S_ISREG(statbuf.st_mode)) { // 레귤러 파일 일때
+            // 앞에서 읽을 수 있는 파일인지 이미 체크했음.
+            resourcePath = tmpPath;
+        }
+    }
+    else if (httpMethod == "POST") { // 요청한 패스가 존재할 수 도 없을 수 도 있음
+        // 경로가 존재하는데 폴더면 문제 발생
+        if (access(tmpPath.c_str(), F_OK) == 0) {
+            if (S_ISDIR(statbuf.st_mode)) { // 디렉터리 일때
+                // bad request 응답하거나 인덱스 페이지를 보여주거나 선택사항임, 지금은 전자.
+                errorCode = 400;
+                // errorPhrase = "Directory file";
+                return 1;
+            }
+        }
+        resourcePath = tmpPath;
+    }
+    else if (httpMethod == "DELETE") {
+        // 리소스가 존재하는가, 삭제 할 수 있는가 체크
+        if (access(tmpPath.c_str(), F_OK) != 0) {
+            errorCode = 404;
+            // errorPhrase = "File not found";
+            return 1;
+        }
+        else if (access(tmpPath.c_str(), W_OK) != 0) {
+            errorCode = 403;
+            // errorPhrase = "File access denied";
+            return 1;
+        }
+        resourcePath = tmpPath;
+    }
+    return 0;
+}
+
+int HttpResponseBuilder::checkAcceptMethod()
+{
+    string httpMethod = requestMessage->getHttpMethod();
+    const vector<string> acceptMethods = locationConfig.getAcceptMethods();
+    
+    if (find(acceptMethods.begin(), acceptMethods.end(), httpMethod) == acceptMethods.end()) {
+        errorCode = 405;
+        return 1;
+    }
+    return 0;
 }
 
 void HttpResponseBuilder::initWebservValues()
-{
+{    
+    webservValues->insert("args", requestMessage->getArgs());
+    webservValues->insert("query_string", requestMessage->getQueryString());
+    webservValues->insert("method", requestMessage->getHttpMethod());
+    webservValues->insert("host", requestMessage->getHeader("Host"));
+    webservValues->insert("content_type", locationConfig.getType(resourcePath));
+    webservValues->insert("request_filename", resourcePath);
     webservValues->insert("request_uri", requestMessage->getRequestUri());
     webservValues->insert("uri", requestMessage->getUri());
     webservValues->insert("document_uri", requestMessage->getUri());
-    
-    // $request_filename 및 resourcePath 초기화
-    vector<string> indexes = locationConfig.getIndexes();
-    struct stat statbuf;
-    string tmpPath = locationConfig.getRoot() + requestMessage->getUri();
-    if (stat(tmpPath.c_str(), &statbuf) < 0) {
-        // 예외처리 하기
-        cout << "stat error:" << tmpPath << endl;
-    }
-
-    if(S_ISDIR(statbuf.st_mode)) { // regular 파일이 없을 때
-        for (int i = 0; i < indexes.size(); i++) {
-            string resourcePathTmp = tmpPath+indexes.at(i);
-            if (access(resourcePathTmp.c_str(), F_OK) == 0) {
-                webservValues->insert("request_filename", "");
-                resourcePath = resourcePathTmp;
-                break;
-            }
-        }
-    }
-    else if (S_ISREG(statbuf.st_mode)) { // regular 파일이 있을 때
-        webservValues->insert("request_filename", requestMessage->getFilename());
-        resourcePath = tmpPath;
-    }
-    // $args 초기화
-    webservValues->insert("args", requestMessage->getArgs());
-
-    // $query_string 초기화
-    webservValues->insert("query_string", requestMessage->getQueryString());
-
-    // $method 초기화
-    webservValues->insert("method", requestMessage->getHttpMethod());
-
-    // $host 초기화
-    webservValues->insert("host", requestMessage->getHeader("Host"));
-
-    // $content-type 초기화
-    webservValues->insert("content_type", locationConfig.getType(requestMessage->getFilename()));
 }
 
 void HttpResponseBuilder::addRequestMessage(const string &request)
 {
     HttpRequestMessage newRequestMessage(request);
-    // post 요청인데 chunk 데이터로 오고 있을 때 동일한 메소드인지 여부 체크하는걸 여기서 할지는 추후에 논의할 예정
-
     needMoreMessageFlag = newRequestMessage.getChunkedFlag();
     requestBody.append(newRequestMessage.getBody());
+    
+    /* 이전과 같은 chunk 요청인지 구별하는 방법은 HTTP 메서드와 URL이 동일함을 확인, Contetn-Length 헤더가 없는것을 확인
+    Transfer-Encoding: chunked 헤더가 지정되어 있는지를 확인하면 됌 */
 }
 
 bool HttpResponseBuilder::getNeedMoreMessageFlag() const
@@ -91,31 +160,24 @@ bool HttpResponseBuilder::getNeedCgiFlag() const
     return needCgiFlag;
 }
 
-
 void HttpResponseBuilder::build(IMethodExecutor & methodExecutor)
 {
     string httpMethod = requestMessage->getHttpMethod();
     string response;
     int statusCode;
-    const vector<string> acceptMethods = locationConfig.getAcceptMethods();
     
-    // accept method check
-    if (find(acceptMethods.begin(), acceptMethods.end(), httpMethod) == acceptMethods.end()) {
-        statusCode = 405; // Method not allowed;
+    // 'if-None-Match', 'if-Match' 와 같은 요청 헤더 지원할 거면 여기서 분기 한번 들어감(선택사항임)
+    
+    if (httpMethod == "GET") {
+        statusCode = methodExecutor.getMethod(resourcePath, response);
     }
-    else {
-        // 'if-None-Match', 'if-Match' 와 같은 요청 헤더 지원할 거면 여기서 분기 한번 들어감(선택사항임)
-        
-        if (httpMethod == "GET") {
-            statusCode = methodExecutor.getMethod(resourcePath, response);
-        }
-        else if(httpMethod == "POST") {
-            statusCode = methodExecutor.postMethod(resourcePath, requestBody, response);
-        }
-        else if(httpMethod == "DELETE") {
-            statusCode = methodExecutor.deleteMethod(resourcePath);
-        }
+    else if(httpMethod == "POST") {
+        statusCode = methodExecutor.postMethod(resourcePath, requestBody, response);
     }
+    else if(httpMethod == "DELETE") {
+        statusCode = methodExecutor.deleteMethod(resourcePath);
+    }
+    
     responseMessage->setServerProtocol(requestMessage->getServerProtocol());
     responseMessage->setStatusCode(statusCode);
     responseMessage->setReasonPhrase(findReasonPhrase(statusCode));
@@ -164,12 +226,42 @@ HttpRequestMessage HttpResponseBuilder::getRequestMessage() const
 
 void HttpResponseBuilder::clear()
 {
-    delete responseMessage;
-    delete requestMessage;
+    if (responseMessage) {
+        delete responseMessage;
+        responseMessage = 0;
+    }
+    if (requestMessage) {
+        delete requestMessage;
+        responseMessage = 0;
+    }
     webservValues->clear();
-    server = 0;
     resourcePath = "";
     requestBody = "";
     needMoreMessageFlag = false;
     needCgiFlag = false;
+}
+
+LocationConfig HttpResponseBuilder::getLocationConfig() const
+{
+    return locationConfig;
+}
+
+void HttpResponseBuilder::setErrorCode(const int & num)
+{
+    errorCode = num;
+}
+
+int HttpResponseBuilder::getErrorCode() const
+{
+    return errorCode;
+}
+
+void HttpResponseBuilder::setErrorPhrase(const string & errorPhrase)
+{
+    this->errorPhrase = errorPhrase;
+}
+
+string HttpResponseBuilder::getErrorPhrase() const
+{
+    return errorPhrase;
 }

--- a/srcs/http/ServerErrors.cpp
+++ b/srcs/http/ServerErrors.cpp
@@ -1,0 +1,107 @@
+#include "ServerErrors.hpp"
+
+string ServerErrors::findErrorMessage(const int & statusCode) const
+{
+    switch(statusCode) {
+        case 100:
+            return "The server has received the request headers and is waiting for the client to send the request body.";
+        case 200:
+            return "The request was successful. The resource has been located and transmitted in the response.";
+        case 201:
+            return "The request has been fulfilled, and a new resource has been created as a result.";
+        case 204:
+            return "The request was successful, but there is no additional content to send in the response.";
+        case 301:
+            return "The requested resource has been permanently moved to a different location.";
+        case 302:
+            return "The requested resource has been temporarily moved to a different location.";
+        case 307:
+            return "The requested resource is temporarily available at a different location.";
+        case 400:
+            return "The request could not be understood by the server due to malformed syntax or invalid parameters.";
+        case 401:
+            return "You are not authorized to access this resource. Please provide valid credentials.";
+        case 403:
+            return "Access to this resource is forbidden. You don't have the necessary permissions.";
+        case 404:
+            return "The page you're looking for could not be found. Please check the URL or try again later.";
+        case 405:
+            return "The requested HTTP method is not allowed for this resource.";
+        case 500:
+            return "An internal server error occurred. We apologize for the inconvenience. Please try again later.";
+        case 503:
+            return "The server is currently unavailable due to maintenance or high load. Please try again later.";
+    }
+    return "An internal server error occurred. We apologize for the inconvenience. Please try again later.";
+}
+
+string ServerErrors::findReasonPhrase(const int & statusCode) const
+{
+    switch(statusCode) {
+        case 100:
+            return "Continue";
+        case 200:
+            return "OK";
+        case 201:
+            return "Created";
+        case 204:
+            return "No Content";
+        case 301:
+            return "Moved Permanently";
+        case 302:
+            return "Found";
+        case 307:
+            return "Temporary Redirect";
+        case 400:
+            return "Bad Request";
+        case 401:
+            return "Unauthorized";
+        case 403:
+            return "Forbidden";
+        case 404:
+            return "Not Found";
+        case 405:
+            return "Method Not Allowed";
+        case 500:
+            return "Internal Server Error";
+        case 503:
+            return "Service Unavailable";
+    }
+    return "Internal Server Error";
+}
+
+string ServerErrors::generateErrorHtml(const int & statusCode) const
+{
+    string reasonPhrase = findReasonPhrase(statusCode);
+    string statusCodeStr = Utils::itoa(statusCode);
+    string message = findErrorMessage(statusCode);
+
+    string errorHtml = "<!DOCTYPE html>\
+    <html>\
+    <head>\
+        <meta charset=\"UTF-8\">\
+        <title> " + statusCodeStr + " " + statusCodeStr + " Not Found</title>\
+        <style>\
+            body {\
+                font-family: Arial, sans-serif;\
+                text-align: center;\
+                padding: 100px;\
+            }\
+            h1 {\
+                font-size: 48px;\
+                margin-bottom: 10px;\
+            }\
+            p {\
+                font-size: 18px;\
+                margin-top: 0;\
+            }\
+        </style>\
+    </head>\
+    <body>\
+        <h1>" + statusCodeStr + " " + reasonPhrase + " Not Found</h1>\
+        <p>" + message + "</p>\
+    </body>\
+    </html>";
+
+    return errorHtml;
+}

--- a/srcs/http/WebservValues.cpp
+++ b/srcs/http/WebservValues.cpp
@@ -44,4 +44,10 @@ string WebservValues::convert(const string &input) const
 void WebservValues::clear()
 {
     envList.clear();
+    envList = addressValues;
+}
+
+void WebservValues::initEnvList()
+{
+    addressValues = envList;
 }


### PR DESCRIPTION
예외처리하다가 구조가 많이 바꼈어요! 
bool타입 변수 end가 추가되었습니당. 이 변수는 ResponsBuilder사용자에게 응답객체가 생성됐는지를 true, false로 알려줘요. 그리고 ServerErrors 클래스가 추가되었어요 -> responseBody가 없는 응답의 경우에는 html 타입의 에러페이지를 갖도록 했습니다.
 잘 돌아가는지는 합치고 테스트해볼께요!!

ResponseBuilder의 흐름은 다음과 같습니다.
1. ResponseBuilder 생성과 동시에 webservValues에 있는 addressValues를 webservValues::addressValues에 백업한다.
2. 사용자가 HttpResponseBuilder::initiate(const string & request)를 실행한다. 
다음부터는 initiate()의 실행흐름입니다.
     1. clear()로 webservValuses에 있는 addressValues를 제외한 나머지를 모두 초기화한다.
     2. parseRequestUri()가 request uri를 파싱한다. 이 과정에서 request uri, uri, filename, args, query string 이 초기화됩니다.
     4. checkAcceptMethod()가 요청 메서드가 accept_method인지 확인한다 -> 틀리면 바로 걸맞는 응답객체를 생성하고 end는 true가 되면서 함수가 **종료**됩니다.
     5. 함수가 종료되지 않았다면, validateResource()가 요청 url이 요청 메서드에 적합한 url인지 확인합니다. 예를 들어 get메서드로 요청이 왔다면 해당 리소스 path는 반드시 존재해야 하고 읽을 수 있어야 합니다. -> 틀리면 바로 걸맞는 응답객체를 생성하고 end는 true가 되면서 함수가 **종료**됩니다.
     6. 함수가 종료되지 않았다면, initWebservValues()가 webservValues 변수를 초기화합니다.
3. 사용자는 ResponseBuilder::getEnd() 메서드를 이용해서 응답객체가 이미 생성(end == true)되었는지 확인합니다. true일때는 HttpResponseMessage::toString()을 통해서 응답스트링을 얻을 수 있습니다.
4. 3번이 해당되지 않았다면, 사용자는 ResponseBuilder::needMoreMessageFlag를 통해 chunk 메시지 여부를 확인하고 적절하게 처리합니다.
5. 사용자가 ResponseBuilder::build(ImethodExecutor & methodExecutor)를 호출하여 응답객체를 만들것을 요청합니다. -> end 변수 값이 true로 바뀜(사용자가 체크할 필요는 없음)
6. 사용자는 HttpResponseMessage::toString()을 통해서 응답스트링을 얻을 수 있습니다.

