### PR TITLE
Feature/#76 error page 지시어 다시 구현 및 cgi 지시어 원래대로 복구

### DIFF
--- a/include/config/LocationConfig.hpp
+++ b/include/config/LocationConfig.hpp
@@ -26,6 +26,7 @@ public:
     bool isErrCode( int code ) const;
     const string & getErrPage( int code ) const;
     bool isCgi( void ) const;
+    const string & getCgi( void ) const;
     bool isAutoIndex( void ) const;
     int  getClientMaxBodySize( void ) const;
     const vector<string> & getAcceptMethods( void ) const;

--- a/include/config/Modules.hpp
+++ b/include/config/Modules.hpp
@@ -28,8 +28,8 @@ protected:
         syntax_error( const string & directive );
     };
 
-    bool isBoolean( const string & str );
-    bool isNumeric( const string & str );
+    static bool isBoolean( const string & str );
+    static bool isNumeric( const string & str );
 
 public:
     Module ( Directive const & directive, enum ModuleType type );

--- a/include/config/Modules.hpp
+++ b/include/config/Modules.hpp
@@ -31,6 +31,7 @@ protected:
     static bool isBoolean( const string & str );
     static bool isNumeric( const string & str );
 
+    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives ) = 0;
 public:
     Module ( Directive const & directive, enum ModuleType type );
     virtual ~Module( void ) {}
@@ -40,15 +41,14 @@ public:
     const vector<Module*> & getSubMods( void ) const;
 
     void addModule( Module * m );
-    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives ) = 0;
 };
 
 class MainModule : public Module
 {
+private:
+    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
 public:
 	MainModule( const Directive & directive );
-
-    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
 };
 
 class ServerModule : public Module
@@ -57,10 +57,9 @@ private:
     uint32_t    ip;
     uint16_t    port;
 
+    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
 public:
 	ServerModule( const Directive & directive, const vector<Directive> & subDirectives );
-
-    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
     
     uint32_t getIp( void ) const;
     uint16_t getPort( void ) const;
@@ -70,10 +69,10 @@ class ServerNameModule : public Module
 {
 private:
     vector<string> serverNames;
-public:
-    ServerNameModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    ServerNameModule( const Directive & directive );
 
     const vector<string> & getServerNames( void ) const;
 };
@@ -82,10 +81,10 @@ class LocationModule : public Module
 {
 private:
     string uri;
-public:
-    LocationModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    LocationModule( const Directive & directive );
 
     const string & getUri( void ) const;
 };
@@ -94,10 +93,10 @@ class RootModule : public Module
 {
 private:
     string root;
-public:
-    RootModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    RootModule( const Directive & directive );
 
     const string & getRoot( void ) const;
 };
@@ -106,10 +105,10 @@ class TypesModule : public Module
 {
 private:
     map<string, string> typesMap;
-public:
-    TypesModule( const Directive & directive, vector<Directive> subDirectives );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    TypesModule( const Directive & directive, vector<Directive> subDirectives );
 
     const map<string, string> & getTypesMap( void ) const;
 };
@@ -118,10 +117,10 @@ class IndexModule : public Module
 {
 private:
     vector<string> indexes;
-public:
-    IndexModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    IndexModule( const Directive & directive );
 
     const vector<string> & getIndexes( void ) const;
 };
@@ -131,10 +130,10 @@ class ErrorPageModule : public Module
 private:
     vector<int> errCodes;
     string      uri;
-public:
-    ErrorPageModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    ErrorPageModule( const Directive & directive );
 
     bool isErrCode( int code ) const;
     const string & getUri( void ) const;
@@ -144,10 +143,10 @@ class CgiModule : public Module
 {
 private:
     string cgiType;
-public:
-    CgiModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    CgiModule( const Directive & directive );
 
     const string & getCgi( void ) const;
 };
@@ -156,10 +155,10 @@ class CgiParamsModule : public Module
 {
 private:
     vector<pair<string, string> > params;
-public:
-    CgiParamsModule( const Directive & directive, const vector<Directive> & subDirectives );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    CgiParamsModule( const Directive & directive, const vector<Directive> & subDirectives );
 
     const vector<pair<string, string> > & getParams( void ) const;
 };
@@ -168,10 +167,10 @@ class AutoIndexModule : public Module
 {
 private:
     bool isAutoIndex;
-public:
-    AutoIndexModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    AutoIndexModule( const Directive & directive );
 
     bool getAutoIndex( void ) const;
 };
@@ -180,10 +179,10 @@ class ClientMaxBodySizeModule : public Module
 {
 private:
     int maxSize;
-public:
-    ClientMaxBodySizeModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    ClientMaxBodySizeModule( const Directive & directive );
 
     int getClientMaxBodySize( void ) const;
 };
@@ -192,10 +191,10 @@ class AcceptMethodModule : public Module
 {
 private:
     vector<string> methods;
-public:
-    AcceptMethodModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+public:
+    AcceptMethodModule( const Directive & directive );
 
     const vector<string> & getAcceptMethods( void ) const;
 };

--- a/include/config/Modules.hpp
+++ b/include/config/Modules.hpp
@@ -143,13 +143,13 @@ public:
 class CgiModule : public Module
 {
 private:
-    bool isCgi; // string으로 변경
+    string cgiType;
 public:
     CgiModule( const Directive & directive );
 
     virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
 
-    bool getCgi( void ) const;
+    const string & getCgi( void ) const;
 };
 
 class CgiParamsModule : public Module

--- a/srcs/config/LocationConfig.cpp
+++ b/srcs/config/LocationConfig.cpp
@@ -133,6 +133,17 @@ bool LocationConfig::isCgi( void ) const
 	if (cgiMod == NULL)
 		return false;
 	
+	return true;
+}
+
+// getCgi메소드를 사용하기전 isCgi를 확인해주는게 좋음
+const string & LocationConfig::getCgi( void ) const
+{
+	static const string defaultCgi = "";
+
+	if (cgiMod == NULL)
+		return defaultCgi;
+
 	return cgiMod->getCgi();
 }
 

--- a/srcs/config/Modules.cpp
+++ b/srcs/config/Modules.cpp
@@ -203,19 +203,16 @@ CgiModule::CgiModule( const Directive & directive ) : Module(directive, LOC_MOD)
 {
 	checkSyntax(directive, NULL);
 
-	if (directive.arg[1] == "on")
-		isCgi = true;
-	else
-		isCgi = false;
+	cgiType = directive.arg[1];
 }
 
 void CgiModule::checkSyntax( const Directive & directive, const vector<Directive> * subDirectives )
 {
-	if (directive.arg.size() != 2 || !isBoolean(directive.arg[1]))
+	if (directive.arg.size() != 2)
 		throw syntax_error("cgi");
 }
 
-bool CgiModule::getCgi( void ) const { return isCgi; }
+const string & CgiModule::getCgi( void ) const { return cgiType; }
 
 // CgiParamsModule
 CgiParamsModule::CgiParamsModule( const Directive & directive, const vector<Directive> & subDirectives ) : Module(directive, LOC_MOD)

--- a/srcs/config/Modules.cpp
+++ b/srcs/config/Modules.cpp
@@ -187,6 +187,12 @@ ErrorPageModule::ErrorPageModule( const Directive & directive ) : Module(directi
 
 void ErrorPageModule::checkSyntax( const Directive & directive, const vector<Directive> * subDirectives )
 {
+	if (directive.arg.size() < 3)
+		throw syntax_error("error_page");
+
+	// arg의 마지막을 제외한 인자에 숫자가 아닌 string이 있다면 에러.
+	if (find_if_not(directive.arg.begin() + 1, directive.arg.end() - 1, isNumeric) != directive.arg.end() - 1)
+		throw syntax_error("error_page");
 }
 
 bool ErrorPageModule::isErrCode( int code ) const 


### PR DESCRIPTION
커밋순서대로
1. cgi 지시어 on/off 에서 확장자명 받는걸로 변경
    getCgi()를 사용하면 cgi확장자명을 리턴한다. 이때 cgi지시어가 없으면 빈 string을 리턴한다.
    cgi 지시어가 config파일에 정의되있는지 확인하는 방법은
    이전처럼 isCgi()를 사용하거나 getCgi()가 빈 string을 리턴하는지 확인하는 방법 두개가 있음.  

2. error_page 지시어 파싱 예외 처리 구현
    딱히 리뷰 안해줘도 괜찬아요