### PR TITLE
Bug: 코드 리팩토링 머지 후 컴파일 오류 해결 및 다시 리팩토링

### DIFF
--- a/include/config/Config.hpp
+++ b/include/config/Config.hpp
@@ -20,8 +20,8 @@ private:
 	Config(Module *mainMod);
 
 public:
-  ~Config();
-  
+	~Config();
+
 	// void getMainConf();
 	const vector<ServerConfig> &getSrvConf(void) const { return srvConfs; }
 };

--- a/include/config/DirectiveTree.hpp
+++ b/include/config/DirectiveTree.hpp
@@ -29,4 +29,5 @@ public:
 	Module *createAutoIndex();
 	Module *createClienMaxBodySize();
 	Module *createAcceptMethod();
+	Module *createReturn();
 };

--- a/include/config/LocationConfig.hpp
+++ b/include/config/LocationConfig.hpp
@@ -6,38 +6,38 @@
 class LocationConfig
 {
 private:
-    RootModule*                 rootMod;
-    IndexModule*                indexMod;
-    TypesModule*                typesMod;
-    CgiModule*                  cgiMod;
-    CgiParamsModule*            cgiParamsMod;
-    AutoIndexModule*            autoIndexMod;
-    AcceptMethodModule*         acceptMethodMod;
-    ClientMaxBodySizeModule*    cliMaxBodyMod;
-    vector<ErrorPageModule*>    errorPageMods;
-    ReturnModule*               returnMod;
+	RootModule *rootMod;
+	IndexModule *indexMod;
+	TypesModule *typesMod;
+	CgiModule *cgiMod;
+	CgiParamsModule *cgiParamsMod;
+	AutoIndexModule *autoIndexMod;
+	AcceptMethodModule *acceptMethodMod;
+	ClientMaxBodySizeModule *cliMaxBodyMod;
+	vector<ErrorPageModule *> errorPageMods;
+	ReturnModule *returnMod;
 
 public:
 	LocationConfig(void);
 
 	void addModules(const vector<Module *> &);
 
-    bool isErrCode( int code ) const;
-    bool isCgi( void ) const;
-    bool isAutoIndex( void ) const;
-    bool isRedirect( void ) const; 
+	bool isErrCode(int code) const;
+	bool isCgi(void) const;
+	bool isAutoIndex(void) const;
+	bool isRedirect(void) const;
 
-    int getClientMaxBodySize( void ) const;
-    int getRedirectStatusCode( void ) const;
+	int getClientMaxBodySize(void) const;
+	int getRedirectStatusCode(void) const;
 
-    const string & getRoot( void ) const;
-    const string & getType( const string & scriptName ) const;
-    const string & getErrPage( int code ) const;
-    const string & getCgi( void ) const;
-    const string & getRedirectUri( void ) const;
+	const string &getRoot(void) const;
+	const string &getType(const string &scriptName) const;
+	const string &getErrPage(int code) const;
+	const string &getCgi(void) const;
+	const string &getRedirectUri(void) const;
 
-    const vector<string> & getIndexes( void ) const;
-    const vector<string> & getAcceptMethods( void ) const;
+	const vector<string> &getIndexes(void) const;
+	const vector<string> &getAcceptMethods(void) const;
 
 	char **getCgiParams(const WebservValues &) const;
 };

--- a/include/config/Modules.hpp
+++ b/include/config/Modules.hpp
@@ -34,8 +34,8 @@ protected:
 	virtual void checkSyntax(const Directive &directive, const vector<Directive> *subDirectives) = 0;
 
 public:
-  Module ( Directive const & directive, enum ModuleType type );
-  virtual ~Module();
+	Module(Directive const &directive, enum ModuleType type);
+	virtual ~Module();
 
 	const string &getName(void) const;
 	const enum ModuleType &getType(void) const;
@@ -164,14 +164,14 @@ public:
 class CgiParamsModule : public Module
 {
 private:
-	vector<pair<string, string>> params;
+	vector<pair<string, string> > params;
 
 	virtual void checkSyntax(const Directive &directive, const vector<Directive> *subDirectives);
 
 public:
 	CgiParamsModule(const Directive &directive, const vector<Directive> &subDirectives);
 
-	const vector<pair<string, string>> &getParams(void) const;
+	const vector<pair<string, string> > &getParams(void) const;
 };
 
 class AutoIndexModule : public Module
@@ -216,13 +216,14 @@ public:
 class ReturnModule : public Module
 {
 private:
-    int     statusCode;
-    string  uri;
+	int statusCode;
+	string uri;
 
-    virtual void checkSyntax( const Directive & directive, const vector<Directive> * subDirectives );
+	virtual void checkSyntax(const Directive &directive, const vector<Directive> *subDirectives);
+
 public:
-    ReturnModule( const Directive & directive );
+	ReturnModule(const Directive &directive);
 
-    int getStatusCode( void ) const; 
-    const string & getUri( void ) const;
+	int getStatusCode(void) const;
+	const string &getUri(void) const;
 };

--- a/srcs/config/DirectiveTree.cpp
+++ b/srcs/config/DirectiveTree.cpp
@@ -49,14 +49,14 @@ Module *DirectiveTree::createModule()
 
 Module *DirectiveTree::createMain()
 {
-	Module * m = new MainModule(directive);
-	
+	Module *m = new MainModule(directive);
+
 	try
 	{
 		for (int i = 0; i < subTree.size(); i++)
 			m->addModule(subTree[i].createModule());
 	}
-	catch(const exception& e)
+	catch (const exception &e)
 	{
 		delete m;
 		m = NULL;
@@ -100,7 +100,7 @@ Module *DirectiveTree::createServer()
 		for (int i = 0; i < subModDirectives.size(); i++)
 			m->addModule(subModDirectives[i]->createModule());
 	}
-	catch(const exception& e)
+	catch (const exception &e)
 	{
 		delete m;
 		m = NULL;
@@ -193,7 +193,7 @@ Module *DirectiveTree::createAcceptMethod()
 	return new AcceptMethodModule(directive);
 }
 
-Module * DirectiveTree::createReturn()
+Module *DirectiveTree::createReturn()
 {
 	return new ReturnModule(directive);
 }

--- a/srcs/config/LocationConfig.cpp
+++ b/srcs/config/LocationConfig.cpp
@@ -158,7 +158,7 @@ char **LocationConfig::getCgiParams(const WebservValues &env) const
 		return paramArr;
 	}
 
-	const vector<pair<string, string>> &params = cgiParamsMod->getParams();
+	const vector<pair<string, string> > &params = cgiParamsMod->getParams();
 
 	char **paramArr = new char *[params.size() + 1];
 
@@ -206,20 +206,20 @@ const vector<string> &LocationConfig::getAcceptMethods(void) const
 	return acceptMethodMod->getAcceptMethods();
 }
 
-bool LocationConfig::isRedirect( void ) const { return (returnMod != NULL); }
+bool LocationConfig::isRedirect(void) const { return (returnMod != NULL); }
 
 // return이 config에 정의되지 않았을 때는 이 메소드를 사용하면 안됨(반드시 isRedirct이후에 사용)
-int LocationConfig::getRedirectStatusCode( void ) const
+int LocationConfig::getRedirectStatusCode(void) const
 {
 	static const int defalutCode = 500; // 기본값이 존재할 수 없기에 서버에러로 일단 설정
 
 	if (returnMod == NULL)
 		return defalutCode;
-	
+
 	return returnMod->getStatusCode();
 }
 
-const string & LocationConfig::getRedirectUri( void ) const
+const string &LocationConfig::getRedirectUri(void) const
 {
 	static const string defalutUri = "";
 

--- a/srcs/config/Modules.cpp
+++ b/srcs/config/Modules.cpp
@@ -2,7 +2,7 @@
 
 // Module
 Module::Module(Directive const &directive, enum ModuleType type)
-  : name(directive.name), type(type) {}
+	: name(directive.name), type(type) {}
 
 Module::~Module()
 {
@@ -249,7 +249,7 @@ void CgiParamsModule::checkSyntax(const Directive &directive, const vector<Direc
 	}
 }
 
-const vector<pair<string, string>> &CgiParamsModule::getParams(void) const { return params; }
+const vector<pair<string, string> > &CgiParamsModule::getParams(void) const { return params; }
 
 // AutoIndexModule
 AutoIndexModule::AutoIndexModule(const Directive &directive) : Module(directive, LOC_MOD)
@@ -309,11 +309,11 @@ ReturnModule::ReturnModule(const Directive &directive) : Module(directive, LOC_M
 	uri = directive.arg[2];
 }
 
-void ReturnModule::checkSyntax(const Directive &directive, const vector<Directive> * subDirectives)
+void ReturnModule::checkSyntax(const Directive &directive, const vector<Directive> *subDirectives)
 {
 	if (directive.arg.size() != 3 || !isNumeric(directive.arg[1]))
 		throw syntax_error("return");
 }
 
 int ReturnModule::getStatusCode(void) const { return statusCode; }
-const string & ReturnModule::getUri(void) const { return uri; }
+const string &ReturnModule::getUri(void) const { return uri; }


### PR DESCRIPTION
스페이스 탭으로 바꾸는 기능 사용 할 때
vector<pair<string, string> >을 
vector<pair<string, string>> 이걸로 바꿔주는데
">>"가 붙어 있으면 컴파일 오류가 나와서 이것만 주의해서 탭으로 바꾸면 될 것 같아요