### PR TITLE
Fix: 통합 테스트 및 문제점 개선하기

### DIFF
--- a/include/http/HttpRequestBuilder.hpp
+++ b/include/http/HttpRequestBuilder.hpp
@@ -40,10 +40,11 @@ private:
 	string path;
 	string httpVersion;
 	map<string,string> headers;
-	string getMethod(const HttpMethodType &methodType) const;
 	int contentLength;
-	bool isChunked;
 	string body;
+	bool isChunked;
+	bool needMoreChunk;
+	string getMethod(const HttpMethodType &methodType) const;
 	void setBuildStep(HttpRequestBuilderBuildStep buildStep);
 	HttpRequestBuilderBuildStep getBuildStep(void);
 	void setMethodType(HttpMethodType methodType);
@@ -60,7 +61,6 @@ private:
 	bool buildFirstLine(string str, bool checkOnly = false);
 	bool setHeader(string str, bool checkOnly = false);
 	string getHeader(string key);
-	int buildChunkedBody(string &recvBuf, string &body, vector<string> &lines, int startIdx);
 	vector<string> split(const string& s, const string& delim);
 
 public:

--- a/include/http/HttpRequestMessage.hpp
+++ b/include/http/HttpRequestMessage.hpp
@@ -10,6 +10,7 @@ class HttpRequestMessage : public HttpMessage
 private:
     string httpMethod;
     string requestTarget;
+    bool needMoreChunk;
     bool chunked;
     bool connection;
     int errorCode;
@@ -20,11 +21,13 @@ public:
                        const string requestTarget,
                        string serverProtocol,
                        map<string, string> headers,
-                       string body);
+                       string body,
+                       bool needMoreChunk);
     string getHttpMethod() const;
     string getRequestTarget() const;
-    bool getChunked() const;
+    bool getNeedMoreChunked() const;
     bool getConnection() const;
+    bool isChunked() const;
     int getErrorCode() const;
 };
 

--- a/srcs/config/LocationConfig.cpp
+++ b/srcs/config/LocationConfig.cpp
@@ -10,6 +10,7 @@ LocationConfig::LocationConfig(void)
 	autoIndexMod = NULL;
 	cliMaxBodyMod = NULL;
 	acceptMethodMod = NULL;
+	returnMod = NULL;
 	errorPageMods.clear();
 }
 

--- a/srcs/http/HttpRequestBuilder.cpp
+++ b/srcs/http/HttpRequestBuilder.cpp
@@ -543,14 +543,14 @@ vector<string> HttpRequestBuilder::split(const string& s, const string& delim)
         end = s.find(delim, start);
         if (end == string::npos)
 		{
-			// if (start >= s.length())
-			// {
-			// 	result.push_back(""); // \r\n 으로 끝난 문자열이면 result 맨마지막에 "" 요소 추가
-			// }
-			// else
-			// {
+			if (start >= s.length())
+			{
+				result.push_back(""); // \r\n 으로 끝난 문자열이면 result 맨마지막에 "" 요소 추가
+			}
+			else
+			{
 				result.push_back(s.substr(start, s.length()));
-			// }
+			}
             break;
         }
     }

--- a/srcs/http/HttpRequestBuilder.cpp
+++ b/srcs/http/HttpRequestBuilder.cpp
@@ -309,6 +309,7 @@ string HttpRequestBuilder::getHeader(string key)
 
 void HttpRequestBuilder::print(void)
 {
+	cout << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" << endl;
 	cout << "BuildStep: " << this->buildStep << endl;
 	cout << "Method: " << this->methodType << endl;
 	cout << "Path: " << this->path << endl;
@@ -323,6 +324,7 @@ void HttpRequestBuilder::print(void)
 
 	cout << endl << "***Body*** (Content-Length: " << this->contentLength << ")" << endl;
 	cout << this->body << endl;
+	cout << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@" << endl << endl;
 }
 
 // return value
@@ -358,10 +360,9 @@ int HttpRequestBuilder::isHttp(string &recvBuf)
 		}
 		if (lines_index == -1)
 		{  // first line이 없는 경우
-			erase();  // 기존에 완성하던 request는 버림
 			recvBuf = lines[lines.size()-1]; // \r\n으로 끝나는 모든 line들 (lines[:-1])은 이미 first line 포맷이 아님을 확인했기에 배제, 마지막 line(lines[-1])만 recvBuf에 남김
-			cout << "[RETURN -1] first line doesn't exist." << endl;
-			return -1;
+			cout << "[RETURN 1] first line doesn't exist." << endl;
+			return 1;
 		}
 	}
 	else

--- a/srcs/http/HttpRequestMessage.cpp
+++ b/srcs/http/HttpRequestMessage.cpp
@@ -4,14 +4,14 @@
 #include <fstream>
 #include <stdlib.h>
 
-HttpRequestMessage::HttpRequestMessage(const string httpMethod, const string requestTarget, string serverProtocol, map<string, string> headers, string body)
+HttpRequestMessage::HttpRequestMessage(const string httpMethod, const string requestTarget, string serverProtocol, map<string, string> headers, string body, bool needMoreChunk)
 {
     this->httpMethod = httpMethod;
     this->requestTarget = requestTarget;
     this->serverProtocol = serverProtocol;
     this->headers = headers;
     this->body = body;
-    chunked = false;
+    this->needMoreChunk = needMoreChunk;
     connection = true;
     errorCode = 500;
     setFlag();
@@ -25,11 +25,11 @@ void HttpRequestMessage::setFlag()
     {
         string headerType = Utils::toLowerCase(it->first);
         string headerValue = it->second;
-        if (headerType == "tansfer-encoding" && headerValue == "chunked")
+        if (headerType == "transfer-encoding" && headerValue == "chunked")
         {
             chunked = true;
         }
-        else if (headerType == "connection" && headerValue == "close")
+        if (headerType == "connection" && headerValue == "close")
         {
             connection = false;
         }
@@ -46,9 +46,9 @@ string HttpRequestMessage::getRequestTarget() const
 	return requestTarget;
 }
 
-bool HttpRequestMessage::getChunked() const
+bool HttpRequestMessage::getNeedMoreChunked() const
 {
-	return chunked;
+	return needMoreChunk;
 }
 
 bool HttpRequestMessage::getConnection() const
@@ -59,4 +59,9 @@ bool HttpRequestMessage::getConnection() const
 int HttpRequestMessage::getErrorCode() const
 {
 	return errorCode;
+}
+
+bool HttpRequestMessage::isChunked() const
+{
+    return chunked;
 }

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -546,6 +546,7 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     
     clear();
     this->requestMessage = requestMessage;
+    this->needMoreMessage = requestMessage->getNeedMoreChunked();
     // 1. uri 구하기
     if ((end = parseRequestUri()) == 1)
     {
@@ -593,7 +594,7 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     // 7. webserv 변수 초기화하기
     initWebservValues();
     // 8. ResponseBuilder 클래스 플래그들 초기화하기
-    needMoreMessage = requestMessage->getChunked();
+    needMoreMessage = requestMessage->getNeedMoreChunked();
     connection = requestMessage->getConnection();
     needCgi = locationConfig.isCgi();
     requestBody = requestMessage->getBody();
@@ -605,7 +606,7 @@ void HttpResponseBuilder::addRequestMessage(HttpRequestMessage *newRequestMessag
     {
         return ;
     }
-    needMoreMessage = newRequestMessage->getChunked();
+    needMoreMessage = newRequestMessage->getNeedMoreChunked();
     connection = newRequestMessage->getConnection();
     requestBody.append(newRequestMessage->getBody());
 

--- a/srcs/http/Utils.cpp
+++ b/srcs/http/Utils.cpp
@@ -19,7 +19,7 @@ vector<string> Utils::split(const string &s, const string &delim)
 	{
 		result.push_back(s.substr(start, end - start));
 		start = end + delim.size();
-		end = s.find_first_of(delim, start);
+		end = s.find(delim, start);
 		if (end == string::npos)
 		{
 			result.push_back(s.substr(start, s.length()));

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -36,7 +36,6 @@ Client::~Client()
 
 void Client::send_msg()
 {
-	// cout << send_buf << endl;
 	cout << "***********send_buf***********" << endl;
 	cout << send_buf << endl;
 	cout << "******************************" << endl << endl;
@@ -60,8 +59,8 @@ void Client::recv_msg()
 		else
 			break;
 	}
+	cout << "***************[" << sock << "]recv_buf***************" << endl;
 	// cout << sock << ">> " << recv_buf << endl;
-	cout << "***********recv_buf***********" << endl;
 	cout << recv_buf << endl;
 	cout << "******************************" << endl << endl;
 }

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -36,13 +36,15 @@ Client::~Client()
 
 void Client::send_msg()
 {
+	// cout << send_buf << endl;
+	cout << "***********send_buf***********" << endl;
 	cout << send_buf << endl;
+	cout << "******************************" << endl << endl;
 	const char *tmp = send_buf.c_str();
 	ssize_t len = send(sock, tmp, strlen(tmp), MSG_DONTWAIT);
 	if (len == -1)
 		throw exception();
 	send_buf = "";
-	recv_buf = "";
 }
 
 void Client::recv_msg()
@@ -58,7 +60,10 @@ void Client::recv_msg()
 		else
 			break;
 	}
-	cout << sock << ">> " << recv_buf << endl;
+	// cout << sock << ">> " << recv_buf << endl;
+	cout << "***********recv_buf***********" << endl;
+	cout << recv_buf << endl;
+	cout << "******************************" << endl << endl;
 }
 
 int Client::getSock() const
@@ -105,6 +110,7 @@ void Client::communicate()
 	if (ret == 0) {
 		if (hrb->getNeedMoreMessage() == false)
 		{
+			httpRequestBuilder->print();
 			hrb->initiate(httpRequestBuilder->createRequestMessage());
 
 			if (hrb->getEnd())


### PR DESCRIPTION
1. isHttp() 에서 buildFirst 스텝에서 첫번째 라인이 완성되지 않았을 때 -1을 리턴하지 않고 1을 리턴하게 변경 (정상적인 요청을 더 지켜보도록)
2. Client::send_msg() 에서 recv_buf 초기화하는거 지움 (isHttp()에서 컨트롤해 줌)
3. LocationConfig 생성자에서 변수 추가 초기화함
4. recv_buf, send_buf 출력해보는거 보기 편하게 살짝 바꿨어요 (기존건 주석처리 했습니다.)
5. RequestBuilder에 needMoreChunk 플래그 추가하고 requestMessage생성 때 넘겨주는거 추가