### PR TITLE
Fix/#92 통합 테스트 및 문제점 개선하기2

### DIFF
--- a/srcs/http/DefaultMethodExecutor.cpp
+++ b/srcs/http/DefaultMethodExecutor.cpp
@@ -8,7 +8,11 @@ int DefaultMethodExecutor::getMethod(const string &resourcePath, string &respons
 	{
 		return 500;
 	}
-	getline(file, response, '\0');
+	string tmp;
+	while (getline(file, tmp))
+	{
+		response += tmp;
+	}
 	file.close();
 	return 200;
 }
@@ -66,7 +70,11 @@ int DefaultMethodExecutor::headMethod(const string &resourcePath, string &respon
 	{
 		return 500;
 	}
-	getline(file, response, '\0');
+	string tmp;
+	while (getline(file, tmp))
+	{
+		response += tmp;
+	}
 	file.close();
 	return 200;
 }

--- a/srcs/http/HttpRequestBuilder.cpp
+++ b/srcs/http/HttpRequestBuilder.cpp
@@ -427,7 +427,8 @@ int HttpRequestBuilder::isHttp(string &recvBuf)
 				{  // chunked number가 나올 차례인 경우
 					if (Utils::isDigitString(lines[i]))
 					{
-						chunked_number = stoi(lines[i], 0, 16);
+						stringstream ss(lines[i]);
+						ss >> std::hex >> chunked_number;
 						if (chunked_number == 0)
 						{  // chunked 2번, chunked number가 0이면 request가 끝이라는 의미
 							needMoreChunk = false;
@@ -488,7 +489,9 @@ int HttpRequestBuilder::isHttp(string &recvBuf)
 			recvBuf = "";
 			if (chunked_number != -1) // 이제 문자열이 나올차례다
 			{
-				recvBuf += to_string(chunked_number) + "\r\n";
+				stringstream ss;
+				ss << std::hex << chunked_number;
+				recvBuf += ss.str() + "\r\n";
 			}
 			recvBuf += lines[lines.size()-1];
 			cout << "[RETURN 1] chunked is not finished." << endl;

--- a/srcs/http/ResponseHeaderAdder.cpp
+++ b/srcs/http/ResponseHeaderAdder.cpp
@@ -18,11 +18,8 @@ void ResponseHeaderAdder::executeAll(HttpResponseBuilder &responseBuilder)
 		addLocationHeader(responseMessage, responseBuilder.getRedirectUri());
 	}
 	// defualt headers
-	if (responseBuilder.getResponseMessage().getBody() != "")
-	{
-		addContentTypeHeader(responseMessage, responseBuilder.getContentType());
-    	addContentLengthHeader(responseMessage, responseBuilder.getResponseMessage().getBody());
-	}
+	addContentTypeHeader(responseMessage, responseBuilder.getContentType());
+	addContentLengthHeader(responseMessage, responseBuilder.getResponseMessage().getBody());
 	addConnectionHeader(responseMessage, responseBuilder.getConnection());
     addDateHeader(responseMessage);
 }

--- a/srcs/http/Utils.cpp
+++ b/srcs/http/Utils.cpp
@@ -59,7 +59,7 @@ bool Utils::isDigitString(string s)
 {
 	for(size_t i = 0; i < s.length(); i++)
 	{
-		if (!isdigit(s[i]))
+		if (!(isdigit(s[i]) || ('a' <= s[i] && s[i] >= 'e') || ('A' <= s[i] && s[i] >= 'E')))
 		{
 			return false;
 		}


### PR DESCRIPTION
- HttpRequestBuilder 클래스에서 사용한 C++11 버전 함수(to_string, stoi)를 c++98버전으로 구현하여 변경
- HttpRequestBuilder::isDigitString 에서 16진수를 허용하도록 변경
- 모든 응답에 대해서 (바디렝스가 0이어도) content-length, content-type 헤더 붙여줌
- DefaultMethodExecutor클래스 GET, HEAD 에서 리소스의 eof까지 responsebody로 가져올 수 있도록 변경
- path info 파싱하는 로직을 ResponseBuilder::initiate() 바로 안으로 위치 이동