### PR TITLE
Feature/#111 kqueue 관련 수정

### DIFF
--- a/include/http/CgiMethodExecutor.hpp
+++ b/include/http/CgiMethodExecutor.hpp
@@ -36,7 +36,7 @@ private:
 	method_step step;
 
 	ServerHandler *sh;
-	Client *client;
+	void *client;
 	char **cgiEnv;
 
 	int stdin_fd;

--- a/include/http/CgiMethodExecutor.hpp
+++ b/include/http/CgiMethodExecutor.hpp
@@ -3,9 +3,12 @@
 #include <iostream>
 #include <string>
 #include <fstream>
-#include "IMethodExecutor.hpp"
 #include <unistd.h>
 #include <cstdlib>
+
+#include "IMethodExecutor.hpp"
+#include "ServerHandler.hpp"
+#include "Client.hpp"
 
 #ifdef __linux__
 #include <signal.h>
@@ -15,27 +18,46 @@
 
 using namespace std;
 
+class ServerHandler;
+class Client;
+
 class CgiMethodExecutor : public IMethodExecutor
 {
 private:
-	const int READ;
-	const int WRITE;
+	static const int READ;
+	static const int WRITE;
+
+	typedef int method_step;
+	static const method_step STEP_FORK_PROC;
+	static const method_step STEP_PROC_DIE;
+	static const method_step STEP_PARENT_WRITE;
+	static const method_step STEP_PARENT_READ;
+	static const method_step STEP_CHILD;
+	method_step step;
+
+	ServerHandler *sh;
+	Client *client;
+	char **cgiEnv;
 
 	int stdin_fd;
 	int stdout_fd;
+	int parent_to_child_pipe[2];
+	int child_to_parent_pipe[2];
 
-	char **cgiEnv;
-	string read_from_pipe();
-	void write_to_pipe(string body);
+	int pid;
+	int exitCode;
+
+	int read_from_pipe(int &fd, string &body);
+	int write_to_pipe(int &fd,  const string &body);
 
 public:
-	CgiMethodExecutor(char **cgiEnv);
+	CgiMethodExecutor(ServerHandler *sh, Client *client, char **cgiEnv);
 	~CgiMethodExecutor();
-	int getMethod(const string &resourcePath, string &response);
-	int postMethod(const string &resourcePath, const string &request, string &response);
-	int deleteMethod(const string &resourcePath) const;
-	int putMethod(const string &resourcePath, const string &request, string &response);
-	int headMethod(const string &resourcePath, string &response);
+	int getMethod(const string &resourcePath, string &response, const int &exitCode);
+	int postMethod(const string &resourcePath, const string &request, string &response, const int &exitCode);
+	int deleteMethod(const string &resourcePath, const int &exitCode) const;
+	int putMethod(const string &resourcePath, const string &request, string &response, const int &exitCode);
+	int headMethod(const string &resourcePath, string &response, const int &exitCode);
 };
 
 #endif

--- a/include/http/DefaultMethodExecutor.hpp
+++ b/include/http/DefaultMethodExecutor.hpp
@@ -3,16 +3,32 @@
 #include "HttpRequestMessage.hpp"
 #include "HttpResponseMessage.hpp"
 #include "IMethodExecutor.hpp"
+#include "ServerHandler.hpp"
+#include "Client.hpp"
 #include <iostream>
 #include <string>
-#include <fstream>
+#include <fcntl.h>
 #include <unistd.h>
 
 using namespace std;
 
+class ServerHandler;
+class Client;
 class DefaultMethodExecutor : public IMethodExecutor
 {
+private:
+	typedef int method_step;
+	static const int STEP_OPEN_FILE = 0x00000001;
+	static const int STEP_IO_OPER = 0x00000002;
+	static const int STEP_FINAL = 0x00000004;
+
+	ServerHandler *sh;
+	Client *client;
+
+	method_step step;
+	int fd;
 public:
+	DefaultMethodExecutor(ServerHandler *sh, Client *client);
 	~DefaultMethodExecutor();
 	int getMethod(const string &resourcePath, string &response);
 	int postMethod(const string &resourcePath, const string &request, string &response);

--- a/include/http/DefaultMethodExecutor.hpp
+++ b/include/http/DefaultMethodExecutor.hpp
@@ -18,9 +18,8 @@ class DefaultMethodExecutor : public IMethodExecutor
 {
 private:
 	typedef int method_step;
-	static const int STEP_OPEN_FILE = 0x00000001;
-	static const int STEP_IO_OPER = 0x00000002;
-	static const int STEP_FINAL = 0x00000004;
+	static const method_step STEP_OPEN_FILE = 0x00000001;
+	static const method_step STEP_IO_OPER = 0x00000002;
 
 	ServerHandler *sh;
 	Client *client;
@@ -30,10 +29,10 @@ private:
 public:
 	DefaultMethodExecutor(ServerHandler *sh, Client *client);
 	~DefaultMethodExecutor();
-	int getMethod(const string &resourcePath, string &response);
-	int postMethod(const string &resourcePath, const string &request, string &response);
-	int deleteMethod(const string &resourcePath) const;
-	int putMethod(const string &resourcePath, const string &request, string &response);
-	int headMethod(const string &resourcePath, string &response);
+	int getMethod(const string &resourcePath, string &response, const int &exitCode);
+	int postMethod(const string &resourcePath, const string &request, string &response, const int &exitCode);
+	int deleteMethod(const string &resourcePath, const int &exitCode) const;
+	int putMethod(const string &resourcePath, const string &request, string &response, const int &exitCode);
+	int headMethod(const string &resourcePath, string &response, const int &exitCode);
 };
 #endif

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -63,7 +63,7 @@ private:
     int checkClientMaxBodySize(const size_t &clientMaxBodySize);
     bool isValidateResource();
     void initWebservValues();
-    void execute();
+    void execute(const int &exitCode);
     void parseCgiProduct();
     void createResponseMessage();
     bool isAllowedRequestMessage();
@@ -76,7 +76,7 @@ public:
     ~HttpResponseBuilder();
     void initiate(HttpRequestMessage *requestMessage);
     void addRequestMessage(HttpRequestMessage *newRequestMessage);
-    void build();
+    void build(const int &exitCode);
     string getResponse() const;
     //getter setter
     HttpResponseMessage &getResponseMessage();
@@ -91,7 +91,7 @@ public:
     string getRedirectUri() const;
     string getContentType() const;
 
-    void setMethodExcutor(IMethodExecutor *mothodExecutor);
+    void setMethodExecutor(IMethodExecutor *mothodExecutor);
 };
 
 #endif

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -6,6 +6,7 @@
 #include "CgiMethodExecutor.hpp"
 #include "WebservValues.hpp"
 #include "ServerConfig.hpp"
+#include "ServerHandler.hpp"
 #include "Server.hpp"
 #include "LocationConfig.hpp"
 #include "ResponseHeaderAdder.hpp"
@@ -55,12 +56,14 @@ private:
     bool connection;
     bool autoIndex;
 
+    IMethodExecutor *methodExecutor;
+
     void clear();
     int parseRequestUri();
     int checkClientMaxBodySize(const size_t &clientMaxBodySize);
     bool isValidateResource();
     void initWebservValues();
-    void execute(IMethodExecutor &methodExecutor);
+    void execute();
     void parseCgiProduct();
     void createResponseMessage();
     bool isAllowedRequestMessage();
@@ -73,7 +76,7 @@ public:
     ~HttpResponseBuilder();
     void initiate(HttpRequestMessage *requestMessage);
     void addRequestMessage(HttpRequestMessage *newRequestMessage);
-    void build(IMethodExecutor &methodExecutor);
+    void build();
     string getResponse() const;
     //getter setter
     HttpResponseMessage &getResponseMessage();
@@ -87,6 +90,8 @@ public:
     string getResourcePath() const;
     string getRedirectUri() const;
     string getContentType() const;
+
+    void setMethodExcutor(IMethodExecutor *mothodExecutor);
 };
 
 #endif

--- a/include/http/IMethodExecutor.hpp
+++ b/include/http/IMethodExecutor.hpp
@@ -10,10 +10,10 @@ class IMethodExecutor
 {
 public:
 	virtual ~IMethodExecutor(){};
-	virtual int getMethod(const string &resourcePath, string &response) = 0;
-	virtual int postMethod(const string &resourcePath, const string &request, string &response) = 0;
-	virtual int deleteMethod(const string &resourcePath) const = 0;
-	virtual int putMethod(const string &resourcePath, const string &request, string &response) = 0;
-	virtual int headMethod(const string &resourcePath, string &response) = 0;
+	virtual int getMethod(const string &resourcePath, string &response, const int &exitCode) = 0;
+	virtual int postMethod(const string &resourcePath, const string &request, string &response, const int &exitCode) = 0;
+	virtual int deleteMethod(const string &resourcePath, const int &exitCode) const = 0;
+	virtual int putMethod(const string &resourcePath, const string &request, string &response, const int &exitCode) = 0;
+	virtual int headMethod(const string &resourcePath, string &response, const int &exitCode) = 0;
 };
 #endif

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -53,7 +53,7 @@ public:
 	bool isSendable() const;
 	bool isBuildable() const;
 
-	void makeResponse();
+	void makeResponse(const int &exitCode);
 };
 
 #endif

--- a/include/server/Client.hpp
+++ b/include/server/Client.hpp
@@ -5,6 +5,7 @@
 #include <exception>
 #include <sys/socket.h>
 
+#include "ServerHandler.hpp"
  #include "Server.hpp"
  #include "HttpResponseBuilder.hpp"
  #include "DefaultMethodExecutor.hpp"
@@ -14,12 +15,14 @@
 
 using namespace std;
 
-class HttpResponseBuilder;
+class ServerHandler;
 class Server;
+class HttpResponseBuilder;
 
 class Client
 {
 private:
+	ServerHandler *sh;
 	Server *server;
 	HttpResponseBuilder *hrb;
 	HttpRequestBuilder *httpRequestBuilder;
@@ -31,8 +34,10 @@ private:
 	string send_buf;
 	string recv_buf;
 
+	bool isBuildableFlag;
+
 public:
-	Client(Server *server);
+	Client(ServerHandler *sh, Server *server);
 	~Client();
 
 	void send_msg();
@@ -46,8 +51,8 @@ public:
 
 	void setSendBuf(string send_buf);
 	bool isSendable() const;
+	bool isBuildable() const;
 
-private:
 	void makeResponse();
 };
 

--- a/include/server/ServerHandler.hpp
+++ b/include/server/ServerHandler.hpp
@@ -17,6 +17,9 @@
 
 using namespace std;
 
+class Server;
+class Client;
+
 class ServerHandler
 {
 private:

--- a/include/server/ServerHandler.hpp
+++ b/include/server/ServerHandler.hpp
@@ -26,6 +26,11 @@ private:
 	vector<struct kevent> changeList; // kqueue 변동 이벤트 (추가 삭제 등)
 	struct kevent eventList[8];			   // kevent()에서 발생한 이벤트 리턴
 	void change_events(uintptr_t ident, int16_t filter, uint16_t flags, uint32_t fflags, intptr_t data, void *udata);
+
+	void handleServerEvent(struct kevent &curEvent, Server *server);
+	void handleClientEvent(struct kevent &curEvent, Client *client);
+	void handleBuildEvent(struct kevent &curEvent);
+
 #elif __linux__
 	vector<struct pollfd> fds;
 #endif

--- a/include/server/ServerHandler.hpp
+++ b/include/server/ServerHandler.hpp
@@ -25,7 +25,6 @@ private:
 	int kq_fd;
 	vector<struct kevent> changeList; // kqueue 변동 이벤트 (추가 삭제 등)
 	struct kevent eventList[8];			   // kevent()에서 발생한 이벤트 리턴
-	void change_events(uintptr_t ident, int16_t filter, uint16_t flags, uint32_t fflags, intptr_t data, void *udata);
 
 	void handleServerEvent(struct kevent &curEvent, Server *server);
 	void handleClientEvent(struct kevent &curEvent, Client *client);
@@ -45,6 +44,7 @@ public:
 	ServerHandler(Config *config);
 	~ServerHandler();
 	void loop();
+	void change_events(uintptr_t ident, int16_t filter, uint16_t flags, uint32_t fflags, intptr_t data, void *udata);
 };
 
 #endif

--- a/srcs/http/DefaultMethodExecutor.cpp
+++ b/srcs/http/DefaultMethodExecutor.cpp
@@ -2,8 +2,10 @@
 
 DefaultMethodExecutor::DefaultMethodExecutor(ServerHandler *sh, Client *client): sh(sh), client(client), step(STEP_OPEN_FILE), fd(-1) {}
 
-int DefaultMethodExecutor::getMethod(const string &resourcePath, string &response)
+int DefaultMethodExecutor::getMethod(const string &resourcePath, string &response, const int &exitCode)
 {
+	(void)exitCode;
+
 	if (step == STEP_OPEN_FILE)
 	{
 		fd = open(resourcePath.c_str(), O_RDONLY | O_NONBLOCK);
@@ -16,7 +18,7 @@ int DefaultMethodExecutor::getMethod(const string &resourcePath, string &respons
 	{
 		char buf[1024];
 		bzero(buf, 1024);
-		int len = read(fd, buf, 1023);
+		ssize_t len = read(fd, buf, 1023);
 		if (len < 0)
 			return 500;
 		else if (len != 1023)
@@ -32,9 +34,9 @@ int DefaultMethodExecutor::getMethod(const string &resourcePath, string &respons
 
 DefaultMethodExecutor::~DefaultMethodExecutor() {}
 
-int DefaultMethodExecutor::postMethod(const string &resourcePath, const string &request, string &response)
+int DefaultMethodExecutor::postMethod(const string &resourcePath, const string &request, string &response, const int &exitCode)
 {
-	static_cast<void>(response);
+	static_cast<void>(response); (void)exitCode;
 	if (step == STEP_OPEN_FILE)
 	{
 		fd = open(resourcePath.c_str(), O_WRONLY | O_NONBLOCK | O_CREAT | O_TRUNC, 0666);
@@ -56,8 +58,9 @@ int DefaultMethodExecutor::postMethod(const string &resourcePath, const string &
 	return 0;
 }
 
-int DefaultMethodExecutor::deleteMethod(const string &resourcePath) const
+int DefaultMethodExecutor::deleteMethod(const string &resourcePath, const int &exitCode) const
 {
+	(void)exitCode;
 	if (remove(resourcePath.c_str()) != 0)
 	{
 		return 500;
@@ -65,56 +68,12 @@ int DefaultMethodExecutor::deleteMethod(const string &resourcePath) const
 	return 204;
 }
 
-int DefaultMethodExecutor::putMethod(const string &resourcePath, const string &request, string &response)
+int DefaultMethodExecutor::putMethod(const string &resourcePath, const string &request, string &response, const int &exitCode)
 {
-	static_cast<void>(response);
-		static_cast<void>(response);
-	if (step == STEP_OPEN_FILE)
-	{
-		fd = open(resourcePath.c_str(), O_WRONLY | O_NONBLOCK  | O_TRUNC | O_CREAT, 0666); //권한 이게 맞나...?
-		if (fd == -1)
-			return 500;
-		step = STEP_IO_OPER;
-		sh->change_events(fd, EVFILT_WRITE, EV_ADD, 0, 0, reinterpret_cast<void*>(client));
-	}
-	else if (step == STEP_IO_OPER)
-	{
-		int cnt = write(fd, request.c_str(), request.length());
-		close(fd);
-		if (cnt != static_cast<ssize_t>(request.length()))
-			return 500;
-		else if (request.length() == 0)
-			return 204;
-		return 201;
-	}
-	return 0;
+	return postMethod(resourcePath, request, response, exitCode);
 }
 
-int DefaultMethodExecutor::headMethod(const string &resourcePath, string &response)
+int DefaultMethodExecutor::headMethod(const string &resourcePath, string &response, const int &exitCode)
 {
-	if (step == STEP_OPEN_FILE)
-	{
-		fd = open(resourcePath.c_str(), O_RDONLY | O_NONBLOCK);
-		if (fd == -1)
-			return 500;
-		step = STEP_IO_OPER;
-		sh->change_events(fd, EVFILT_READ, EV_ADD, 0, 0, reinterpret_cast<void*>(client));
-	}
-	else if (step == STEP_IO_OPER)
-	{
-		char buf[1024];
-		bzero(buf, 1024);
-		int len = read(fd, buf, 1023);
-		if (len < 0)
-			return 500;
-		else if (len != 1023)
-			step = STEP_FINAL;
-		response += string(buf);
-	}
-	else if (step == STEP_FINAL)
-	{
-		close(fd);
-		return 200;
-	}
-	return 0;
+	return getMethod(resourcePath, response, exitCode);
 }

--- a/srcs/http/DefaultMethodExecutor.cpp
+++ b/srcs/http/DefaultMethodExecutor.cpp
@@ -8,6 +8,7 @@ int DefaultMethodExecutor::getMethod(const string &resourcePath, string &respons
 
 	if (step == STEP_OPEN_FILE)
 	{
+		cout << "STEP_OPEN_FILE" << endl;
 		fd = open(resourcePath.c_str(), O_RDONLY | O_NONBLOCK);
 		if (fd == -1)
 			return 500;
@@ -16,6 +17,7 @@ int DefaultMethodExecutor::getMethod(const string &resourcePath, string &respons
 	}
 	else if (step == STEP_IO_OPER)
 	{
+		cout << "STEP_IO_OPER" << endl;
 		char buf[1024];
 		bzero(buf, 1024);
 		ssize_t len = read(fd, buf, 1023);

--- a/srcs/http/DefaultMethodExecutor.cpp
+++ b/srcs/http/DefaultMethodExecutor.cpp
@@ -37,7 +37,7 @@ int DefaultMethodExecutor::postMethod(const string &resourcePath, const string &
 	static_cast<void>(response);
 	if (step == STEP_OPEN_FILE)
 	{
-		fd = open(resourcePath.c_str(), O_WRONLY | O_NONBLOCK);
+		fd = open(resourcePath.c_str(), O_WRONLY | O_NONBLOCK | O_CREAT | O_TRUNC, 0666);
 		if (fd == -1)
 			return 500;
 		step = STEP_IO_OPER;
@@ -71,7 +71,7 @@ int DefaultMethodExecutor::putMethod(const string &resourcePath, const string &r
 		static_cast<void>(response);
 	if (step == STEP_OPEN_FILE)
 	{
-		fd = open(resourcePath.c_str(), O_WRONLY | O_NONBLOCK);
+		fd = open(resourcePath.c_str(), O_WRONLY | O_NONBLOCK  | O_TRUNC | O_CREAT, 0666); //권한 이게 맞나...?
 		if (fd == -1)
 			return 500;
 		step = STEP_IO_OPER;
@@ -79,9 +79,9 @@ int DefaultMethodExecutor::putMethod(const string &resourcePath, const string &r
 	}
 	else if (step == STEP_IO_OPER)
 	{
-		int cnt = write(fd, resourcePath.c_str(), resourcePath.length());
+		int cnt = write(fd, request.c_str(), request.length());
 		close(fd);
-		if (cnt != static_cast<ssize_t>(resourcePath.length()))
+		if (cnt != static_cast<ssize_t>(request.length()))
 			return 500;
 		else if (request.length() == 0)
 			return 204;

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -36,8 +36,13 @@ HttpResponseBuilder::~HttpResponseBuilder()
     if (requestMessage)
     {
         delete requestMessage;
-        responseMessage = 0;
+        requestMessage = 0;
     }
+	if (methodExecutor)
+	{
+		delete methodExecutor;
+        methodExecutor = 0;
+	}
 }
 
 void HttpResponseBuilder::clear()
@@ -608,7 +613,12 @@ void HttpResponseBuilder::build(const int &exitCode)
     if (statusCode == 0)
         return ;
     createResponseMessage();
-    end = true;  
+    end = true;
+	if (methodExecutor)
+	{
+		delete methodExecutor;
+        methodExecutor = 0;
+	}
 }
 
 HttpRequestMessage HttpResponseBuilder::getRequestMessage() const

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -334,30 +334,30 @@ void HttpResponseBuilder::setSpecifiedErrorPage(const int &errorCode)
     }
 }
 
-void HttpResponseBuilder::execute()
+void HttpResponseBuilder::execute(const int &exitCode)
 {
 	string httpMethod = requestMessage->getHttpMethod();
 
 	// 'if-None-Match', 'if-Match' 와 같은 요청 헤더 지원할 거면 여기서 분기 한번 들어감(선택사항임)
 	if (httpMethod == "GET")
 	{
-		statusCode = methodExecutor->getMethod(resourcePath, responseBody);
+		statusCode = methodExecutor->getMethod(resourcePath, responseBody, exitCode);
 	}
 	else if (httpMethod == "POST")
 	{
-		statusCode = methodExecutor->postMethod(resourcePath, requestBody, responseBody);
+		statusCode = methodExecutor->postMethod(resourcePath, requestBody, responseBody, exitCode);
 	}
 	else if (httpMethod == "DELETE")
 	{
-		statusCode = methodExecutor->deleteMethod(resourcePath);
+		statusCode = methodExecutor->deleteMethod(resourcePath, exitCode);
 	}
 	else if (httpMethod == "PUT")
 	{
-		statusCode = methodExecutor->putMethod(resourcePath, requestBody, responseBody);
+		statusCode = methodExecutor->putMethod(resourcePath, requestBody, responseBody, exitCode);
 	}
 	else if (httpMethod == "HEAD")
 	{
-		statusCode = methodExecutor->headMethod(resourcePath, responseBody);
+		statusCode = methodExecutor->headMethod(resourcePath, responseBody, exitCode);
 	}
 }
 
@@ -602,9 +602,9 @@ void HttpResponseBuilder::addRequestMessage(HttpRequestMessage *newRequestMessag
     requestBody.append(newRequestMessage->getBody());
 }
 
-void HttpResponseBuilder::build()
+void HttpResponseBuilder::build(const int &exitCode)
 {
-    execute();
+    execute(exitCode);
     if (statusCode == 0)
         return ;
     createResponseMessage();
@@ -682,7 +682,7 @@ string HttpResponseBuilder::getContentType() const
     return contentType;
 }
 
-void HttpResponseBuilder::setMethodExcutor(IMethodExecutor *methodExecutor)
+void HttpResponseBuilder::setMethodExecutor(IMethodExecutor *methodExecutor)
 {
     this->methodExecutor = methodExecutor;
 }

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -158,5 +158,8 @@ void Client::makeResponse(const int &exitCode)
 {
 	hrb->build(exitCode);
 	if (hrb->getEnd())
+	{
 		this->send_buf = hrb->getResponse();
+		// hrb->deleteMethodExecutor();
+	}
 }

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -15,7 +15,7 @@ Client::Client(ServerHandler *sh, Server *server) : sh(sh), server(server), isBu
 	fcntl(sock, F_SETFL, flags | O_NONBLOCK);
 #endif
 
-	cout << "Connet: Client" << sock << endl;
+	cout << "Connect: Client" << sock << endl;
 	cout << inet_ntoa(addr.sin_addr) << ":" << ntohs(addr.sin_port) << endl;
 	webVal.insert("server_addr", server->getIP());
 	webVal.insert("server_port", server->getPort());
@@ -36,7 +36,7 @@ Client::~Client()
 
 void Client::send_msg()
 {
-	cout << "***********send_buf***********" << endl;
+	cout << "***********send_buf[" << sock << "]***********" << endl;
 	cout << send_buf << endl;
 	cout << "******************************" << endl << endl;
 	const char *tmp = send_buf.c_str();
@@ -120,7 +120,7 @@ void Client::communicate()
 	if (ret == 0) {
 		if (hrb->getNeedMoreMessage() == false)
 		{
-			httpRequestBuilder->print();
+			// httpRequestBuilder->print();
 			hrb->initiate(httpRequestBuilder->createRequestMessage());
 
 			if (hrb->getEnd())

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -144,19 +144,19 @@ void Client::communicate()
 			if (hrb->getNeedCgi() == true)
 			{
 				LocationConfig lc = hrb->getLocationConfig();
-				executor = new CgiMethodExecutor(lc.getCgiParams(webVal));
+				executor = new CgiMethodExecutor(sh, this, lc.getCgiParams(webVal));
 			}
 			else
 				executor = new DefaultMethodExecutor(sh, this);
-			hrb->setMethodExcutor(executor);
+			hrb->setMethodExecutor(executor);
 			isBuildableFlag = true;
 		}
 	}
 }
 
-void Client::makeResponse(void)
+void Client::makeResponse(const int &exitCode)
 {
-	hrb->build();
+	hrb->build(exitCode);
 	if (hrb->getEnd())
 		this->send_buf = hrb->getResponse();
 }

--- a/srcs/server/ServerHandler.cpp
+++ b/srcs/server/ServerHandler.cpp
@@ -137,7 +137,7 @@ void ServerHandler::handleClientEvent(struct kevent &curEvent, Client *client)
 		}
 		else if (client->isBuildable())
 		{
-			client->makeResponse();
+			client->makeResponse(-1);
 			if (client->isSendable())
 				change_events(client->getSock(), EVFILT_WRITE, EV_ENABLE, 0, 0, NULL);
 			else
@@ -163,9 +163,13 @@ void ServerHandler::handleClientEvent(struct kevent &curEvent, Client *client)
 
 void ServerHandler::handleBuildEvent(struct kevent &curEvent)
 {
+	int exitCode = -1;
+	if (curEvent.filter == EVFILT_PROC)
+		exitCode = curEvent.data;
+	cout << "==================================================a==EXIT_CODE: " << exitCode << endl;
 	void *tmp = curEvent.udata;
 	Client *client = reinterpret_cast<Client*>(tmp);
-	client->makeResponse();
+	client->makeResponse(exitCode);
 	if (client->isSendable())
 	{
 		change_events(client->getSock(), EVFILT_WRITE, EV_ENABLE, 0, 0, NULL);

--- a/srcs/server/ServerHandler.cpp
+++ b/srcs/server/ServerHandler.cpp
@@ -137,8 +137,11 @@ void ServerHandler::handleClientEvent(struct kevent &curEvent, Client *client)
 		}
 		else if (client->isBuildable())
 		{
-			change_events(client->getSock(), EVFILT_READ, EV_DISABLE, 0, 0, NULL);
 			client->makeResponse();
+			if (client->isSendable())
+				change_events(client->getSock(), EVFILT_WRITE, EV_ENABLE, 0, 0, NULL);
+			else
+				change_events(client->getSock(), EVFILT_READ, EV_DISABLE, 0, 0, NULL);
 		}
 	}
 	else if (curEvent.filter == EVFILT_WRITE)

--- a/srcs/server/ServerHandler.cpp
+++ b/srcs/server/ServerHandler.cpp
@@ -152,8 +152,8 @@ void ServerHandler::handleClientEvent(struct kevent &curEvent, Client *client)
 				delete client;
 				return ;
 			}
-			change_events(client->getSock(), EVFILT_READ, EV_DISABLE, 0, 0, NULL);
-			change_events(client->getSock(), EVFILT_WRITE, EV_ENABLE, 0, 0, NULL);
+			change_events(client->getSock(), EVFILT_READ, EV_ENABLE, 0, 0, NULL);
+			change_events(client->getSock(), EVFILT_WRITE, EV_DISABLE, 0, 0, NULL);
 		}
 	}
 }

--- a/tester.conf
+++ b/tester.conf
@@ -1,5 +1,5 @@
 server {
-    listen 127.0.0.1:8080;
+    listen 127.0.0.1:8081;
 
     server_name localhost;
     index index.html;
@@ -10,6 +10,8 @@ server {
 	  }
 
     location / {
+        cgi py;
+        index index.py
         accept_method GET;
     }
 


### PR DESCRIPTION
executor에서 여는 파일 디스크립터, 파이프 디스크립터, 자식 프로세스 pid를 kqueue에 등록해서 사용할 수 있도록 수정했습니다!

1. ServerHandler::loop() 에서 이벤트 주체 별로 함수 쪼갬 (Server, Client, executor(build))
2. client의 타이머 이벤트 추가
3. executor가 hrb에 등록되도록 변경
4. isHttp()처럼 executor의 실행 단계를 나누어 놓고 이벤트 발생시마다 계속 실행시키도록 변경
---
# 아직 해결 못한 문제
- [ ] content-type response에 반영 안 됨.
- [ ] 이미지 못 읽는 문제
- [ ] 빈 파일인 경우 읽기 이벤트 발생 안함 -> response 생성 불가