### PR TITLE
Fix: Content-type header 붙도록 고침, Utils::split 고침

### DIFF
--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -374,6 +374,7 @@ void HttpResponseBuilder::parseCgiProduct()
     {
         // \n 기준으로 스플릿된 아이들을 모두 헤더임
         string headersLine = responseBody.substr(0, lflf);
+        cout << headersLine << endl;
         vector<string> headers = Utils::split(headersLine, "\n");
         for (size_t i = 0; i < headers.size(); i++) 
         {
@@ -589,7 +590,9 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     }
     // 8. webserv 변수 초기화하기
     initWebservValues();
-    // 9. ResponseBuilder 클래스 플래그들 초기화하기
+    // 9. Content-type 초기화
+    contentType = locationConfig.getType(resourcePath);
+    // 10. ResponseBuilder 클래스 플래그들 초기화하기
     needMoreMessage = requestMessage->getNeedMoreChunked();
     connection = requestMessage->getConnection();
     needCgi = locationConfig.isCgi();

--- a/srcs/http/Utils.cpp
+++ b/srcs/http/Utils.cpp
@@ -15,6 +15,11 @@ vector<string> Utils::split(const string &s, const string &delim)
 	vector<string> result;
 	size_t start = 0;
 	size_t end = s.find(delim);
+	if (end == string::npos)
+	{
+		result.push_back(s);
+		return result;
+	}
 	while (end != string::npos)
 	{
 		result.push_back(s.substr(start, end - start));


### PR DESCRIPTION
### 수정 사항
리뷰 안해줘도 괜찮아요!
- HttpResponseBuilder::contentType 변수를 세팅하는 부분이 누락되서 추가하였습니다.
- Utils::split()에서 delimeter가 아예 없는 스트링을 받을 경우도 result에 포함하도록 수정하였습니다.