### PR TITLE
Fix/#113 content type헤더 오류 수정 및 나머지 문제 개선

### DIFF
--- a/include/http/HttpRequestBuilder.hpp
+++ b/include/http/HttpRequestBuilder.hpp
@@ -30,10 +30,8 @@ private:
 		PUT,
 		HEAD,
 		DELETE,
-		OPTIONS,
-		PATCH,
-		TRACE,
 	};
+	map<string, HttpMethodType> httpMethods;
 	HttpRequestBuilderBuildStep buildStep;
 	HttpMethodType methodType;
 	string method;

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -374,6 +374,7 @@ void HttpResponseBuilder::parseCgiProduct()
     {
         // \n 기준으로 스플릿된 아이들을 모두 헤더임
         string headersLine = responseBody.substr(0, lflf);
+        cout << headersLine << endl;
         vector<string> headers = Utils::split(headersLine, "\n");
         for (size_t i = 0; i < headers.size(); i++) 
         {
@@ -589,7 +590,9 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     }
     // 8. webserv 변수 초기화하기
     initWebservValues();
-    // 9. ResponseBuilder 클래스 플래그들 초기화하기
+    // 9. Content-type 초기화
+    contentType = locationConfig.getType(resourcePath);
+    // 10. ResponseBuilder 클래스 플래그들 초기화하기
     needMoreMessage = requestMessage->getNeedMoreChunked();
     connection = requestMessage->getConnection();
     needCgi = locationConfig.isCgi();

--- a/srcs/http/Utils.cpp
+++ b/srcs/http/Utils.cpp
@@ -15,6 +15,11 @@ vector<string> Utils::split(const string &s, const string &delim)
 	vector<string> result;
 	size_t start = 0;
 	size_t end = s.find(delim);
+	if (end == string::npos)
+	{
+		result.push_back(s);
+		return result;
+	}
 	while (end != string::npos)
 	{
 		result.push_back(s.substr(start, end - start));

--- a/webserv.sh
+++ b/webserv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# 지정된 파일 이름
+filename="./tester.conf"
+
+# 파일이 존재하는지 확인
+if [ ! -f "$filename" ]; then
+    echo "File $filename not found!"
+    exit 1
+fi
+
+# 현재의 포트 번호를 추출 (첫 번째로 찾은 것만 사용)
+current_port=$(grep -m 1 -o '127\.0\.0\.1:[0-9]\+' "$filename" | awk -F: '{ print $2 }')
+
+# 만약 포트 번호가 없다면 종료
+if [ -z "$current_port" ]; then
+    echo "No port number found in $filename."
+    exit 1
+fi
+
+# 포트 번호를 8080에서 8090 사이로 순환 증가
+new_port=$(((current_port - 8080 + 1) % 11 + 8080))
+
+# sed를 사용하여 파일 내용을 변경 (macOS와 Linux에서 동작)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' "s/127.0.0.1:$current_port/127.0.0.1:$new_port/g" "$filename"
+else
+    # Linux
+    sed -i "s/127.0.0.1:$current_port/127.0.0.1:$new_port/g" "$filename"
+fi
+
+#echo "Port changed from $current_port to $new_port in $filename"
+./webserv tester.conf


### PR DESCRIPTION
### 수정 사항
리뷰 안해줘도 괜찮아요!

- HttpResponseBuilder::contentType 변수를 세팅하는 부분이 누락되서 추가하였습니다.
- Utils::split()에서 delimeter가 아예 없는 스트링을 받을 경우도 result에 포함하도록 수정하였습니다.
- isHttp()에서 지원하지 않는 메서드의 startline까지 받아서 return 0 하도록 수정하였습니다.
- isHttp() 에서 snake 형식 변수를 camel로 변경하고 코드 이해를 위한 주석을 더했습니다.
### 추가 사항
- tester.conf 포트 번호 수정한 후 webserv 실행해주는 쉘스크립트 webserv.sh 를 작성하였습니다.
사용법은 아래와 같습니다.
1. `chmod +x webserv.sh` 로 실행권한을 준다.
2. `bash webserv.sh` 로 실행한다.