### PR TITLE
Fix/#116 communicate수정

### DIFF
--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -55,7 +55,8 @@ private:
     bool end;
     bool connection;
     bool autoIndex;
-
+    bool invalidRequest;
+    
     IMethodExecutor *methodExecutor;
 
     void clear();

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -56,7 +56,7 @@ private:
     bool connection;
     bool autoIndex;
     bool invalidRequest;
-    
+    int previousStatusCode;
     IMethodExecutor *methodExecutor;
 
     void clear();
@@ -66,16 +66,17 @@ private:
     void initWebservValues();
     void execute(const int &exitCode);
     void parseCgiProduct();
-    void createResponseMessage();
     bool isAllowedRequestMessage();
-    void setSpecifiedErrorPage(const int &errorCode);
+    // void setSpecifiedErrorPage(const int &errorCode);
     bool isRedirectRequest();
 
 public:
-    void createInvalidResponseMessage();
+    void createResponseMessage();
+    void changeRequestMessage(const int &errorCode);
+    // void createInvalidResponseMessage();
     HttpResponseBuilder(const Server *server, WebservValues &webservValues);
     ~HttpResponseBuilder();
-    void initiate(HttpRequestMessage *requestMessage);
+    void initiate(HttpRequestMessage *requestMessage, int preStatusCode = 0);
     void addRequestMessage(HttpRequestMessage *newRequestMessage);
     void build(const int &exitCode);
     string getResponse() const;
@@ -91,6 +92,7 @@ public:
     string getResourcePath() const;
     string getRedirectUri() const;
     string getContentType() const;
+    int getStatusCode() const;
 
     void setMethodExecutor(IMethodExecutor *mothodExecutor);
 };

--- a/include/http/HttpResponseBuilder.hpp
+++ b/include/http/HttpResponseBuilder.hpp
@@ -55,7 +55,6 @@ private:
     bool end;
     bool connection;
     bool autoIndex;
-    bool invalidRequest;
     int previousStatusCode;
     IMethodExecutor *methodExecutor;
 
@@ -67,13 +66,11 @@ private:
     void execute(const int &exitCode);
     void parseCgiProduct();
     bool isAllowedRequestMessage();
-    // void setSpecifiedErrorPage(const int &errorCode);
     bool isRedirectRequest();
 
 public:
     void createResponseMessage();
     void changeRequestMessage(const int &errorCode);
-    // void createInvalidResponseMessage();
     HttpResponseBuilder(const Server *server, WebservValues &webservValues);
     ~HttpResponseBuilder();
     void initiate(HttpRequestMessage *requestMessage, int preStatusCode = 0);

--- a/srcs/http/HttpRequestBuilder.cpp
+++ b/srcs/http/HttpRequestBuilder.cpp
@@ -362,6 +362,12 @@ int HttpRequestBuilder::isHttp(string &recvBuf)
 		if (lines[i].length() == 0)
 		{	// empty line //size -1 까지만 보기 때문에 \r\n으로 끝난놈과 \r\n\r\n으로 끝난 놈을 구별할 필요X 무조건 \r\n\r\n으로 끝난 놈임
 			cout << "EMPTY LINE" << i << endl;
+			if (headers.find("host") == headers.end())
+			{
+				recvBuf = Utils::stringJoin(lines, "\r\n", i+1);
+				cout << "[RETURN -1] request must be include host header." << endl;
+				return -1;
+			}
 			if (getBuildStep() == BUILD_HEADER && bodyRequired)
 			{  	// header finish (header를 완성한 뒤 body로 넘어가는 경우)
 				setBuildStep(BUILD_BODY);

--- a/srcs/http/HttpRequestBuilder.cpp
+++ b/srcs/http/HttpRequestBuilder.cpp
@@ -236,6 +236,17 @@ bool HttpRequestBuilder::setHeader(string str, bool checkOnly)
 	if (!checkOnly)
 	{
 		string lowerKey = Utils::toLowerCase(key);
+		
+		// content-length와 host는 중복되면 잘못된 요청으로 간주함.
+		if (!lowerKey.compare("content-length") && this->headers.find("content-length") != headers.end())
+		{
+			return false;
+		}
+		else if (!lowerKey.compare("host") && this->headers.find("host") != headers.end())
+		{
+			return false;
+		}
+		
 		this->headers[lowerKey] = value;
 
 		if (!lowerKey.compare("content-length"))
@@ -329,6 +340,7 @@ int HttpRequestBuilder::isHttp(string &recvBuf)
 		{	// 구현되지 않은 메서드는 바로 return 0
 			if (methodType == METHOD_TYPE_NONE)
 			{
+				recvBuf = Utils::stringJoin(lines, "\r\n", linesIndex+1);
 				cout << "[RETURN 0] not implemented method" << endl;
 				return 0;
 			}

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -23,6 +23,7 @@ HttpResponseBuilder::HttpResponseBuilder(const Server *server, WebservValues &we
 	connection = true;
 	autoIndex = false;
     invalidRequest = false;
+    previousStatusCode = 0;
 
     methodExecutor = NULL;
 }
@@ -76,6 +77,7 @@ void HttpResponseBuilder::clear()
 	connection = true;
 	autoIndex = false;
     invalidRequest = false;
+    previousStatusCode = 0;
 
     if (methodExecutor)
     {
@@ -139,6 +141,7 @@ bool HttpResponseBuilder::isValidateResource()
         if (access(tmpPath.c_str(), F_OK) != 0)
         {
             statusCode = 404;
+            cout << "HERE: " << statusCode << endl;
             return 1;
         }
         else if (access(tmpPath.c_str(), R_OK) != 0)
@@ -241,105 +244,105 @@ void HttpResponseBuilder::initWebservValues()
 	webservValues->insert("fastcgi_path_info", pathInfo);
 }
 
-void HttpResponseBuilder::setSpecifiedErrorPage(const int &errorCode)
-{
-    string errorPage = locationConfig.getErrPage(statusCode);
-    ResponseStatusManager responseStatusManager;
-    ServerAutoIndexSimulator serverAutoIndexSimulator;
-    LocationConfig redirectedLocationConfig;
-    redirectedLocationConfig = server->getConfig(requestMessage->getHeader("host")).getLocConf(errorPage);
-    string root = redirectedLocationConfig.getRoot();
+// void HttpResponseBuilder::setSpecifiedErrorPage(const int &errorCode)
+// {
+//     string errorPage = locationConfig.getErrPage(statusCode);
+//     ResponseStatusManager responseStatusManager;
+//     ServerAutoIndexSimulator serverAutoIndexSimulator;
+//     LocationConfig redirectedLocationConfig;
+//     redirectedLocationConfig = server->getConfig(requestMessage->getHeader("host")).getLocConf(errorPage);
+//     string root = redirectedLocationConfig.getRoot();
 
-    string path = root + errorPage;
-    // 1. 에러페이지 경로 존재 유무 확인
-    if (access(path.c_str(), F_OK) != 0)
-    {
-        // a. 경로가 존재하지 않으면 기본 내장 파일 사용 (but, fall back 에러 페이지가 있다면 그걸 사용)
-        responseBody = responseStatusManager.generateResponseHtml(errorCode);
-        return ;
-    }
-    // 2. 에러페이지 읽기 권한 확인
-    if (access(path.c_str(), R_OK) != 0)
-    {
-        // a. 권한없으면 403 에러 대신 띄움 (but, fall back 에러 페이지가 있다면 그걸 사용)
-        statusCode = 403;
-        if (locationConfig.isErrCode(statusCode) == true)
-        {
-            setSpecifiedErrorPage(statusCode);
-        }
-        return ;
-    }
-    // 여기서 부터 에러페이지가 실존하고 권한도 있는 상태
-    struct stat statbuf;
-    if (stat(path.c_str(), &statbuf) < 0)
-    {
-        statusCode = 500;
-        if (locationConfig.isErrCode(statusCode) == true)
-        {
-            setSpecifiedErrorPage(statusCode);
-        }
-        return ;
-    }
-    // 3. 에러페이지가 폴더다
-    if (S_ISDIR(statbuf.st_mode))
-    {
-        // a. index지시어가 지정되어 있고, index파일이 있다면 그 파일로 대체
-        const vector<string> &indexes = redirectedLocationConfig.getIndexes();
-        bool exist = false;
-        for (size_t i = 0; i < indexes.size(); i++)
-        {
-            string tmpPath = path + indexes.at(i);
-            if (access(tmpPath.c_str(), R_OK) == 0)
-            {
-                exist = true;
-                // reponse body에 저장(GET Method와 동일)
-                ifstream file(tmpPath.c_str());
-                if (file.fail())
-                {
-                    if (redirectedLocationConfig.isErrCode(500) == true)
-                    {
-                        statusCode = 500;
-                        setSpecifiedErrorPage(statusCode);
-                        return;
-                    }
-                }
-                getline(file, responseBody, '\0');
-                file.close();
-                return ;
-            }
-        }
-        // b. index지시어가 없거나 유효한 index.html이 없다.
-        if(exist == false)
-        {
-            if (redirectedLocationConfig.isAutoIndex() == true)
-            {
-                // auto index가 on 이면 폴더의 내용을 나열한다.
-                responseBody = serverAutoIndexSimulator.generateAutoIndexHtml(root, errorPage);
-            }
-            else
-            {
-                // 모두 다 해당하지 않는다면 내장 에러페이지 사용한다.
-                responseBody = responseStatusManager.generateResponseHtml(statusCode);
-            }
-        }
-    }
-    else if(S_ISREG(statbuf.st_mode))
-    {
-        // 4. 에러페이지가 파일이면 바로 저장한다.
-        ifstream file(path.c_str());
-        if (file.fail())
-        {
-            if (redirectedLocationConfig.isErrCode(500) == true)
-            {
-                statusCode = 500;
-                setSpecifiedErrorPage(statusCode);
-                return;
-            }
-        }
-        getline(file, responseBody, '\0');
-        file.close();
-    }
-}
+//     string path = root + errorPage;
+//     // 1. 에러페이지 경로 존재 유무 확인
+//     if (access(path.c_str(), F_OK) != 0)
+//     {
+//         // a. 경로가 존재하지 않으면 기본 내장 파일 사용 (but, fall back 에러 페이지가 있다면 그걸 사용)
+//         responseBody = responseStatusManager.generateResponseHtml(errorCode);
+//         return ;
+//     }
+//     // 2. 에러페이지 읽기 권한 확인
+//     if (access(path.c_str(), R_OK) != 0)
+//     {
+//         // a. 권한없으면 403 에러 대신 띄움 (but, fall back 에러 페이지가 있다면 그걸 사용)
+//         statusCode = 403;
+//         if (locationConfig.isErrCode(statusCode) == true)
+//         {
+//             setSpecifiedErrorPage(statusCode);
+//         }
+//         return ;
+//     }
+//     // 여기서 부터 에러페이지가 실존하고 권한도 있는 상태
+//     struct stat statbuf;
+//     if (stat(path.c_str(), &statbuf) < 0)
+//     {
+//         statusCode = 500;
+//         if (locationConfig.isErrCode(statusCode) == true)
+//         {
+//             setSpecifiedErrorPage(statusCode);
+//         }
+//         return ;
+//     }
+//     // 3. 에러페이지가 폴더다
+//     if (S_ISDIR(statbuf.st_mode))
+//     {
+//         // a. index지시어가 지정되어 있고, index파일이 있다면 그 파일로 대체
+//         const vector<string> &indexes = redirectedLocationConfig.getIndexes();
+//         bool exist = false;
+//         for (size_t i = 0; i < indexes.size(); i++)
+//         {
+//             string tmpPath = path + indexes.at(i);
+//             if (access(tmpPath.c_str(), R_OK) == 0)
+//             {
+//                 exist = true;
+//                 // reponse body에 저장(GET Method와 동일)
+//                 ifstream file(tmpPath.c_str());
+//                 if (file.fail())
+//                 {
+//                     if (redirectedLocationConfig.isErrCode(500) == true)
+//                     {
+//                         statusCode = 500;
+//                         setSpecifiedErrorPage(statusCode);
+//                         return;
+//                     }
+//                 }
+//                 getline(file, responseBody, '\0');
+//                 file.close();
+//                 return ;
+//             }
+//         }
+//         // b. index지시어가 없거나 유효한 index.html이 없다.
+//         if(exist == false)
+//         {
+//             if (redirectedLocationConfig.isAutoIndex() == true)
+//             {
+//                 // auto index가 on 이면 폴더의 내용을 나열한다.
+//                 responseBody = serverAutoIndexSimulator.generateAutoIndexHtml(root, errorPage);
+//             }
+//             else
+//             {
+//                 // 모두 다 해당하지 않는다면 내장 에러페이지 사용한다.
+//                 responseBody = responseStatusManager.generateResponseHtml(statusCode);
+//             }
+//         }
+//     }
+//     else if(S_ISREG(statbuf.st_mode))
+//     {
+//         // 4. 에러페이지가 파일이면 바로 저장한다.
+//         ifstream file(path.c_str());
+//         if (file.fail())
+//         {
+//             if (redirectedLocationConfig.isErrCode(500) == true)
+//             {
+//                 statusCode = 500;
+//                 setSpecifiedErrorPage(statusCode);
+//                 return;
+//             }
+//         }
+//         getline(file, responseBody, '\0');
+//         file.close();
+//     }
+// }
 
 void HttpResponseBuilder::execute(const int &exitCode)
 {
@@ -414,28 +417,28 @@ string HttpResponseBuilder::getResponse() const
     return response;
 }
 
-void HttpResponseBuilder::createInvalidResponseMessage()
-{
-    ResponseStatusManager responseStatusManager;
+// void HttpResponseBuilder::createInvalidResponseMessage()
+// {
+//     ResponseStatusManager responseStatusManager;
     
-    responseMessage = new HttpResponseMessage();
-    ResponseHeaderAdder responseHeaderAdder;
+//     responseMessage = new HttpResponseMessage();
+//     ResponseHeaderAdder responseHeaderAdder;
 
-    statusCode = 400;
-    connection = false; // 커넥션 끊기
-    if (locationConfig.isErrCode(statusCode))
-    {
-        setSpecifiedErrorPage(statusCode);
-    }
-    else
-    {
-        responseBody = responseStatusManager.generateResponseHtml(statusCode);
-    }
-    responseMessage->setStatusCode(statusCode);
-    responseMessage->setReasonPhrase(responseStatusManager.findReasonPhrase(statusCode));
-    responseMessage->setBody(responseBody);
-    responseHeaderAdder.executeAll(*this);
-}
+//     statusCode = 400;
+//     connection = false; // 커넥션 끊기
+//     if (locationConfig.isErrCode(statusCode))
+//     {
+//         setSpecifiedErrorPage(statusCode);
+//     }
+//     else
+//     {
+//         responseBody = responseStatusManager.generateResponseHtml(statusCode);
+//     }
+//     responseMessage->setStatusCode(statusCode);
+//     responseMessage->setReasonPhrase(responseStatusManager.findReasonPhrase(statusCode));
+//     responseMessage->setBody(responseBody);
+//     responseHeaderAdder.executeAll(*this);
+// }
 
 void HttpResponseBuilder::createResponseMessage()
 {
@@ -459,10 +462,10 @@ void HttpResponseBuilder::createResponseMessage()
     string httpMethod = requestMessage->getHttpMethod();
 
     //커스텀 에러페이지 있는지 체크
-    if (locationConfig.isErrCode(statusCode))
-    {
-        setSpecifiedErrorPage(statusCode);
-    }
+    // if (locationConfig.isErrCode(statusCode))
+    // {
+    //     setSpecifiedErrorPage(statusCode);
+    // }
     responseMessage->setStatusCode(statusCode);
     responseMessage->setReasonPhrase(responseStatusManager.findReasonPhrase(statusCode));
     if (autoIndex)
@@ -526,37 +529,33 @@ bool HttpResponseBuilder::isRedirectRequest()
     return 0;
 }
 
-void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
+void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage, int previousStatusCode)
 {
     
     clear();
     if (!requestMessage)
     {   // isHttp()가 -1을 리턴한 경우
-        invalidRequest = true;
         createResponseMessage();
         return ;
     }
-
+    this->previousStatusCode = previousStatusCode;
     this->requestMessage = requestMessage;
     this->needMoreMessage = requestMessage->getNeedMoreChunked();
+    cout << "??2: " << requestMessage << endl;
+    cout << "NEW REQUEST: " << "$$$" << requestMessage->getRequestTarget() << endl;
     // 1. uri 구하기
-    if ((end = parseRequestUri()) == 1)
-    {
-        createResponseMessage();
-        return ;
-    }
+    parseRequestUri();
+    print();
     // 2. uri 바탕으로 locationConfig 구하기
     locationConfig = server->getConfig(requestMessage->getHeader("host")).getLocConf(uri);
     // 3. 리다이렉트 지시문 체크
     if ((end = isRedirectRequest()) == 1)
     {
-        createResponseMessage();
         return ;
     }
     // 4. locationConfig 메서드를 이용해서 accept_method, accepted_method, client_max_body_size 체크
     if ((end = isAllowedRequestMessage()) == 1)
     {
-        createResponseMessage();
         return ;
     }
     // 5. pathinfo parsing
@@ -608,7 +607,6 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     // 7. uri 경로 유효성 검사하기
     if ((end = isValidateResource()) == 1)
     {
-        createResponseMessage();
         return ;
     }
     // 8. webserv 변수 초기화하기
@@ -620,6 +618,7 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     connection = requestMessage->getConnection();
     needCgi = locationConfig.isCgi();
     requestBody = requestMessage->getBody();
+    cout << "SUCCESS: " << previousStatusCode << endl;;
 }
 
 void HttpResponseBuilder::addRequestMessage(HttpRequestMessage *newRequestMessage)
@@ -633,16 +632,49 @@ void HttpResponseBuilder::addRequestMessage(HttpRequestMessage *newRequestMessag
     requestBody.append(newRequestMessage->getBody());
 }
 
+void HttpResponseBuilder::changeRequestMessage(const int &errorCode)
+{
+    cout << "ERROR CODE: " << errorCode << endl;
+    string errorPageName = locationConfig.getErrPage(errorCode);
+    // LocationConfig redirectedLc = server->getConfig(requestMessage->getHeader("host")).getLocConf(errorPageName);
+    // string requestTarget = redirectedLc.getRoot() + errorPageName;
+    map<string, string> headers;
+    headers.insert(make_pair<string, string>("host", requestMessage->getHeader("host")));
+    //response builder 초기화 안해도 됌 initate에서 초기화 해주기 때문에.
+    initiate(new HttpRequestMessage("GET", errorPageName, "HTTP/1.1", headers, "", false), statusCode);
+}
+
 void HttpResponseBuilder::build(const int &exitCode)
 {
-    if (invalidRequest == false)
-    {   // 정상적인 요청만 execute를 실행할 것
-        execute(exitCode);
+    if (previousStatusCode)
+    {   // custom Page를 GET하러 온 경우임
+        if (!end)
+        {   // 유효성 검사 성공
+            execute(exitCode);
+        }
     }
+    else
+    {   // 첫 요청이 유효성 검사에 성공한 경우
+        execute(exitCode);
+        if (locationConfig.isErrCode(statusCode) && requestMessage->getHeaders().size())
+        {
+            changeRequestMessage(statusCode);
+            build(exitCode);
+        }
+    }
+
     if (statusCode == 0)
+    {
         return ;
+    }
+    else if (previousStatusCode)
+    {
+        statusCode = previousStatusCode;
+    }
+
     createResponseMessage();
     end = true;
+
 	if (methodExecutor)
 	{
 		delete methodExecutor;
@@ -703,6 +735,7 @@ void HttpResponseBuilder::print()
     cout << "end: " << end << endl;
     cout << "connection: " << connection << endl;
     cout << "autoIndex: " << autoIndex << endl;
+    cout << "previousStatusCode: " << previousStatusCode << endl; 
     cout << "***** HttpResponseBuilder print end *****" << endl;
 }
 
@@ -724,4 +757,9 @@ string HttpResponseBuilder::getContentType() const
 void HttpResponseBuilder::setMethodExecutor(IMethodExecutor *methodExecutor)
 {
     this->methodExecutor = methodExecutor;
+}
+
+int HttpResponseBuilder::getStatusCode() const
+{
+    return this->statusCode;
 }

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -12,6 +12,8 @@ HttpResponseBuilder::HttpResponseBuilder(const Server *server, WebservValues &we
 	filename = "";
 	args = "";
 	queryString = "";
+    pathInfo = "";
+    redirectUri = "";
 	resourcePath = "";
 	requestBody = "";
 	contentType = "";
@@ -62,9 +64,10 @@ void HttpResponseBuilder::clear()
 	requestUri = "";
 	uri = "";
 	filename = "";
-	pathInfo = "";
 	args = "";
 	queryString = "";
+    pathInfo = "";
+    redirectUri = "";
 	resourcePath = "";
 	requestBody = "";
 	contentType = "";
@@ -139,7 +142,6 @@ bool HttpResponseBuilder::isValidateResource()
         if (access(tmpPath.c_str(), F_OK) != 0)
         {
             statusCode = 404;
-            cout << "HERE: " << statusCode << endl;
             return 1;
         }
         else if (access(tmpPath.c_str(), R_OK) != 0)
@@ -403,13 +405,13 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage, int previ
 {
     
     clear();
+    this->previousStatusCode = previousStatusCode;
+    this->requestMessage = requestMessage;
     if (!requestMessage)
     {   // isHttp()가 -1을 리턴한 경우
         createResponseMessage();
         return ;
     }
-    this->previousStatusCode = previousStatusCode;
-    this->requestMessage = requestMessage;
     this->needMoreMessage = requestMessage->getNeedMoreChunked();
     // 1. uri 구하기
     parseRequestUri();

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -22,7 +22,6 @@ HttpResponseBuilder::HttpResponseBuilder(const Server *server, WebservValues &we
 	end = false;
 	connection = true;
 	autoIndex = false;
-    invalidRequest = false;
     previousStatusCode = 0;
 
     methodExecutor = NULL;
@@ -76,7 +75,6 @@ void HttpResponseBuilder::clear()
 	end = false;
 	connection = true;
 	autoIndex = false;
-    invalidRequest = false;
     previousStatusCode = 0;
 
     if (methodExecutor)
@@ -244,106 +242,6 @@ void HttpResponseBuilder::initWebservValues()
 	webservValues->insert("fastcgi_path_info", pathInfo);
 }
 
-// void HttpResponseBuilder::setSpecifiedErrorPage(const int &errorCode)
-// {
-//     string errorPage = locationConfig.getErrPage(statusCode);
-//     ResponseStatusManager responseStatusManager;
-//     ServerAutoIndexSimulator serverAutoIndexSimulator;
-//     LocationConfig redirectedLocationConfig;
-//     redirectedLocationConfig = server->getConfig(requestMessage->getHeader("host")).getLocConf(errorPage);
-//     string root = redirectedLocationConfig.getRoot();
-
-//     string path = root + errorPage;
-//     // 1. 에러페이지 경로 존재 유무 확인
-//     if (access(path.c_str(), F_OK) != 0)
-//     {
-//         // a. 경로가 존재하지 않으면 기본 내장 파일 사용 (but, fall back 에러 페이지가 있다면 그걸 사용)
-//         responseBody = responseStatusManager.generateResponseHtml(errorCode);
-//         return ;
-//     }
-//     // 2. 에러페이지 읽기 권한 확인
-//     if (access(path.c_str(), R_OK) != 0)
-//     {
-//         // a. 권한없으면 403 에러 대신 띄움 (but, fall back 에러 페이지가 있다면 그걸 사용)
-//         statusCode = 403;
-//         if (locationConfig.isErrCode(statusCode) == true)
-//         {
-//             setSpecifiedErrorPage(statusCode);
-//         }
-//         return ;
-//     }
-//     // 여기서 부터 에러페이지가 실존하고 권한도 있는 상태
-//     struct stat statbuf;
-//     if (stat(path.c_str(), &statbuf) < 0)
-//     {
-//         statusCode = 500;
-//         if (locationConfig.isErrCode(statusCode) == true)
-//         {
-//             setSpecifiedErrorPage(statusCode);
-//         }
-//         return ;
-//     }
-//     // 3. 에러페이지가 폴더다
-//     if (S_ISDIR(statbuf.st_mode))
-//     {
-//         // a. index지시어가 지정되어 있고, index파일이 있다면 그 파일로 대체
-//         const vector<string> &indexes = redirectedLocationConfig.getIndexes();
-//         bool exist = false;
-//         for (size_t i = 0; i < indexes.size(); i++)
-//         {
-//             string tmpPath = path + indexes.at(i);
-//             if (access(tmpPath.c_str(), R_OK) == 0)
-//             {
-//                 exist = true;
-//                 // reponse body에 저장(GET Method와 동일)
-//                 ifstream file(tmpPath.c_str());
-//                 if (file.fail())
-//                 {
-//                     if (redirectedLocationConfig.isErrCode(500) == true)
-//                     {
-//                         statusCode = 500;
-//                         setSpecifiedErrorPage(statusCode);
-//                         return;
-//                     }
-//                 }
-//                 getline(file, responseBody, '\0');
-//                 file.close();
-//                 return ;
-//             }
-//         }
-//         // b. index지시어가 없거나 유효한 index.html이 없다.
-//         if(exist == false)
-//         {
-//             if (redirectedLocationConfig.isAutoIndex() == true)
-//             {
-//                 // auto index가 on 이면 폴더의 내용을 나열한다.
-//                 responseBody = serverAutoIndexSimulator.generateAutoIndexHtml(root, errorPage);
-//             }
-//             else
-//             {
-//                 // 모두 다 해당하지 않는다면 내장 에러페이지 사용한다.
-//                 responseBody = responseStatusManager.generateResponseHtml(statusCode);
-//             }
-//         }
-//     }
-//     else if(S_ISREG(statbuf.st_mode))
-//     {
-//         // 4. 에러페이지가 파일이면 바로 저장한다.
-//         ifstream file(path.c_str());
-//         if (file.fail())
-//         {
-//             if (redirectedLocationConfig.isErrCode(500) == true)
-//             {
-//                 statusCode = 500;
-//                 setSpecifiedErrorPage(statusCode);
-//                 return;
-//             }
-//         }
-//         getline(file, responseBody, '\0');
-//         file.close();
-//     }
-// }
-
 void HttpResponseBuilder::execute(const int &exitCode)
 {
 	string httpMethod = requestMessage->getHttpMethod();
@@ -417,29 +315,6 @@ string HttpResponseBuilder::getResponse() const
     return response;
 }
 
-// void HttpResponseBuilder::createInvalidResponseMessage()
-// {
-//     ResponseStatusManager responseStatusManager;
-    
-//     responseMessage = new HttpResponseMessage();
-//     ResponseHeaderAdder responseHeaderAdder;
-
-//     statusCode = 400;
-//     connection = false; // 커넥션 끊기
-//     if (locationConfig.isErrCode(statusCode))
-//     {
-//         setSpecifiedErrorPage(statusCode);
-//     }
-//     else
-//     {
-//         responseBody = responseStatusManager.generateResponseHtml(statusCode);
-//     }
-//     responseMessage->setStatusCode(statusCode);
-//     responseMessage->setReasonPhrase(responseStatusManager.findReasonPhrase(statusCode));
-//     responseMessage->setBody(responseBody);
-//     responseHeaderAdder.executeAll(*this);
-// }
-
 void HttpResponseBuilder::createResponseMessage()
 {
 
@@ -461,11 +336,6 @@ void HttpResponseBuilder::createResponseMessage()
     
     string httpMethod = requestMessage->getHttpMethod();
 
-    //커스텀 에러페이지 있는지 체크
-    // if (locationConfig.isErrCode(statusCode))
-    // {
-    //     setSpecifiedErrorPage(statusCode);
-    // }
     responseMessage->setStatusCode(statusCode);
     responseMessage->setReasonPhrase(responseStatusManager.findReasonPhrase(statusCode));
     if (autoIndex)
@@ -541,11 +411,8 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage, int previ
     this->previousStatusCode = previousStatusCode;
     this->requestMessage = requestMessage;
     this->needMoreMessage = requestMessage->getNeedMoreChunked();
-    cout << "??2: " << requestMessage << endl;
-    cout << "NEW REQUEST: " << "$$$" << requestMessage->getRequestTarget() << endl;
     // 1. uri 구하기
     parseRequestUri();
-    print();
     // 2. uri 바탕으로 locationConfig 구하기
     locationConfig = server->getConfig(requestMessage->getHeader("host")).getLocConf(uri);
     // 3. 리다이렉트 지시문 체크
@@ -618,7 +485,6 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage, int previ
     connection = requestMessage->getConnection();
     needCgi = locationConfig.isCgi();
     requestBody = requestMessage->getBody();
-    cout << "SUCCESS: " << previousStatusCode << endl;;
 }
 
 void HttpResponseBuilder::addRequestMessage(HttpRequestMessage *newRequestMessage)
@@ -634,10 +500,7 @@ void HttpResponseBuilder::addRequestMessage(HttpRequestMessage *newRequestMessag
 
 void HttpResponseBuilder::changeRequestMessage(const int &errorCode)
 {
-    cout << "ERROR CODE: " << errorCode << endl;
     string errorPageName = locationConfig.getErrPage(errorCode);
-    // LocationConfig redirectedLc = server->getConfig(requestMessage->getHeader("host")).getLocConf(errorPageName);
-    // string requestTarget = redirectedLc.getRoot() + errorPageName;
     map<string, string> headers;
     headers.insert(make_pair<string, string>("host", requestMessage->getHeader("host")));
     //response builder 초기화 안해도 됌 initate에서 초기화 해주기 때문에.

--- a/srcs/http/HttpResponseBuilder.cpp
+++ b/srcs/http/HttpResponseBuilder.cpp
@@ -444,13 +444,13 @@ void HttpResponseBuilder::createResponseMessage()
     ResponseStatusManager responseStatusManager;
     ResponseHeaderAdder responseHeaderAdder;
     
-    if (invalidRequest == true)
+    if (!requestMessage)
     {
         statusCode = 400;
         connection = false; // 커넥션 끊기
-        responseBody = responseStatusManager.generateResponseHtml(statusCode);
         responseMessage->setStatusCode(statusCode);
         responseMessage->setReasonPhrase(responseStatusManager.findReasonPhrase(statusCode));
+        responseBody = responseStatusManager.generateResponseHtml(statusCode);
         responseMessage->setBody(responseBody);
         responseHeaderAdder.executeAll(*this);
         return ;
@@ -533,6 +533,7 @@ void HttpResponseBuilder::initiate(HttpRequestMessage *requestMessage)
     if (!requestMessage)
     {   // isHttp()가 -1을 리턴한 경우
         invalidRequest = true;
+        createResponseMessage();
         return ;
     }
 

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -137,11 +137,9 @@ void Client::communicate()
 	LocationConfig lc = hrb->getLocationConfig();
 	if (hrb->getEnd())
 	{
-		cout << "end is one" << endl;
 		// 구현되지 않은 요청을 받은 경우에는 requestMessage 객체에 firstLine밖에 안들어있어서 애초에 lc를 확인할 수 없음
 		if (lc.isErrCode(hrb->getStatusCode()) && hrb->getRequestMessage().getHeaders().size())
 		{
-			cout << "IS ERROR CODE" << endl;
 			hrb->changeRequestMessage(hrb->getStatusCode());
 		}
 		else

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -113,8 +113,9 @@ void Client::communicate()
 	}
 	else if (ret == -1)
 	{
-		hrb->createInvalidResponseMessage();
-		send_buf = hrb->getResponse();
+		hrb->initiate(NULL);
+		// hrb->createInvalidResponseMessage();
+		// send_buf = hrb->getResponse();
 		return ;
 	}
 	else if (ret == 0)

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -114,8 +114,7 @@ void Client::communicate()
 	else if (ret == -1)
 	{
 		hrb->initiate(NULL);
-		// hrb->createInvalidResponseMessage();
-		// send_buf = hrb->getResponse();
+		send_buf = hrb->getResponse();
 		return ;
 	}
 	else if (ret == 0)

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -111,47 +111,38 @@ void Client::communicate()
 	{
 		return ;
 	}
-	if (ret == -1)
+	else if (ret == -1)
 	{
 		hrb->createInvalidResponseMessage();
 		send_buf = hrb->getResponse();
 		return ;
 	}
-	if (ret == 0) {
+	else if (ret == 0)
+	{
 		if (hrb->getNeedMoreMessage() == false)
 		{
-			// httpRequestBuilder->print();
 			hrb->initiate(httpRequestBuilder->createRequestMessage());
-
-			if (hrb->getEnd())
-			{
-				send_buf = hrb->getResponse();
-				return;
-			}
 		}
 		else
 		{
 			hrb->addRequestMessage(httpRequestBuilder->createRequestMessage());
-			if (hrb->getEnd())
-			{
-				send_buf = hrb->getResponse();
-				return ;
-			}
 		}
-		if (hrb->getNeedMoreMessage() == false)
+
+		if (hrb->getNeedMoreMessage() == true)
 		{
-			IMethodExecutor *executor;
-			if (hrb->getNeedCgi() == true)
-			{
-				LocationConfig lc = hrb->getLocationConfig();
-				executor = new CgiMethodExecutor(sh, this, lc.getCgiParams(webVal));
-			}
-			else
-				executor = new DefaultMethodExecutor(sh, this);
-			hrb->setMethodExecutor(executor);
-			isBuildableFlag = true;
+			return ;
 		}
 	}
+	IMethodExecutor *executor;
+	if (hrb->getNeedCgi() == true)
+	{
+		LocationConfig lc = hrb->getLocationConfig();
+		executor = new CgiMethodExecutor(sh, this, lc.getCgiParams(webVal));
+	}
+	else
+		executor = new DefaultMethodExecutor(sh, this);
+	hrb->setMethodExecutor(executor);
+	isBuildableFlag = true;
 }
 
 void Client::makeResponse(const int &exitCode)

--- a/srcs/server/Client.cpp
+++ b/srcs/server/Client.cpp
@@ -133,10 +133,29 @@ void Client::communicate()
 			return ;
 		}
 	}
+	
+	LocationConfig lc = hrb->getLocationConfig();
+	if (hrb->getEnd())
+	{
+		cout << "end is one" << endl;
+		// 구현되지 않은 요청을 받은 경우에는 requestMessage 객체에 firstLine밖에 안들어있어서 애초에 lc를 확인할 수 없음
+		if (lc.isErrCode(hrb->getStatusCode()) && hrb->getRequestMessage().getHeaders().size())
+		{
+			cout << "IS ERROR CODE" << endl;
+			hrb->changeRequestMessage(hrb->getStatusCode());
+		}
+		else
+		{
+			hrb->createResponseMessage();
+			send_buf = hrb->getResponse();
+			return ;
+		}
+	}
+	
 	IMethodExecutor *executor;
 	if (hrb->getNeedCgi() == true)
 	{
-		LocationConfig lc = hrb->getLocationConfig();
+		lc = hrb->getLocationConfig();
 		executor = new CgiMethodExecutor(sh, this, lc.getCgiParams(webVal));
 	}
 	else
@@ -148,6 +167,7 @@ void Client::communicate()
 void Client::makeResponse(const int &exitCode)
 {
 	hrb->build(exitCode);
+
 	if (hrb->getEnd())
 	{
 		this->send_buf = hrb->getResponse();


### PR DESCRIPTION
리뷰안해줘도 괜찮지만 해주면 좋습니다.
### 수정 사항

- HttpRequestBuilder::isHttp() 수정
     - HTTP 1.1 버전에서는 host헤더를 필수적으로 요구하는 것을 고려하였습니다.
     - HTTP 1.1 버전에서는 content-length 헤더가 중복되는 경우 비정상적인 요청으로 판단하는 것을 고려하였습니다.
- commuincate() 구조를 의논했던 방향으로 수정했습니다. 여파로 HttpRequestBuilder의 메서드들도 수정이 있었습니다.
      - 예외사항으로는 원래는 isHttp()가 -1을 리턴하는 비정상적인 요청의 경우에도 custom error page 지시어를 고려해주는 방향으로 구현하려고 했었지만, 구현 과정에서 custom error page 지시어를 고려 안하는것이 합리적이다 생각해서 default error page를 담고 종료하는 것으로 했습니다.
